### PR TITLE
Control cameras using a joystick

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,3 @@
+[run]
+omit = src/staldates/ui/resources.py
+

--- a/src/staldates/avcontrol.py
+++ b/src/staldates/avcontrol.py
@@ -100,10 +100,12 @@ def main():
 
         if os.path.exists("/dev/input/js0"):
             js = Joystick("/dev/input/js0")
+            js.start()
         else:
             js = None
 
         jsa = CameraJoystickAdapter(js)
+        jsa.start()
         myapp = MainWindow(controller, jsa)
 
         client = AvControlClient(myapp)

--- a/src/staldates/avcontrol.py
+++ b/src/staldates/avcontrol.py
@@ -2,6 +2,7 @@ import argparse
 import atexit
 import fcntl  # @UnresolvedImport
 import logging
+import os
 import Pyro4
 import sys
 
@@ -13,6 +14,7 @@ from staldates.ui import resources  # @UnusedImport  # Initialises the Qt resour
 from staldates.ui.MainWindow import MainWindow
 from staldates.ui.widgets import Dialogs
 from staldates.ui.widgets.Dialogs import handlePyroErrors
+from staldates.joystick import Joystick, CameraJoystickAdapter
 
 
 Pyro4.config.COMMTIMEOUT = 3  # seconds
@@ -96,7 +98,13 @@ def main():
     try:
         controller = Controller.fromPyro(args.c)
 
-        myapp = MainWindow(controller)
+        if os.path.exists("/dev/input/js0"):
+            js = Joystick("/dev/input/js0")
+        else:
+            js = None
+
+        jsa = CameraJoystickAdapter(js)
+        myapp = MainWindow(controller, jsa)
 
         client = AvControlClient(myapp)
         client.setDaemon(True)

--- a/src/staldates/avcontrol.py
+++ b/src/staldates/avcontrol.py
@@ -84,6 +84,8 @@ def main():
                         help="Specify the controller ID to connect to",
                         metavar="CONTROLLERID",
                         default="")
+    parser.add_argument("-j", "--joystick",
+                        help="Path to joystick device to use for camera control")
     args = parser.parse_args()
 
     try:
@@ -98,11 +100,20 @@ def main():
     try:
         controller = Controller.fromPyro(args.c)
 
-        if os.path.exists("/dev/input/js0"):
-            js = Joystick("/dev/input/js0")
-            js.start()
-        else:
-            js = None
+        js = None
+        joystickDevice = args.joystick
+        print args
+        try:
+            if args.joystick:
+                if os.path.exists(joystickDevice):
+                    logging.info("Configuring joystick {}".format(joystickDevice))
+                    js = Joystick(joystickDevice)
+                    js.start()
+                else:
+                    logging.error("Specified joystick device {} does not exist!".format(joystickDevice))
+        except IOError:
+            logging.exception("Unable to configure joystick")
+            pass
 
         jsa = CameraJoystickAdapter(js)
         jsa.start()

--- a/src/staldates/joystick.py
+++ b/src/staldates/joystick.py
@@ -121,7 +121,8 @@ def zoom_speed_from_axis(axis):
 class CameraJoystickAdapter(Thread):
     def __init__(self, js, map_pan=pan_speed_from_axis, map_tilt=tilt_speed_from_axis, map_zoom=zoom_speed_from_axis):
         super(CameraJoystickAdapter, self).__init__()
-        js.add_axis_handler(self._handle_axis)
+        if js:
+            js.add_axis_handler(self._handle_axis)
         self._axes = [0, 0, 0, 0]
         self.map_pan = map_pan
         self.map_tilt = map_tilt

--- a/src/staldates/joystick.py
+++ b/src/staldates/joystick.py
@@ -38,17 +38,20 @@ class Joystick(Thread):
         for handler in self._button_handlers:
             handler(button, value)
 
+    def parse_event(self, evt):
+        _, value, evt_type, number = struct.unpack(EVENT_FORMAT, evt)
+
+        if (evt_type & ~EVENT_INIT) == EVENT_AXIS:
+            # print "{} Axis {}: value {}".format(time, number, value)
+            self._on_axis(number, value)
+        elif (evt_type & ~EVENT_INIT) == EVENT_BUTTON:
+            # print "{} Button {}: value {}".format(time, number, value)
+            self._on_button(number, value)
+
     def run(self):
         while True:
             evt = self.device.read(EVENT_SIZE)
-            time, value, evt_type, number = struct.unpack(EVENT_FORMAT, evt)
-
-            if (evt_type & ~EVENT_INIT) == EVENT_AXIS:
-                # print "{} Axis {}: value {}".format(time, number, value)
-                self._on_axis(number, value)
-            elif (evt_type & ~EVENT_INIT) == EVENT_BUTTON:
-                # print "{} Button {}: value {}".format(time, number, value)
-                self._on_button(number, value)
+            self.parse_event(evt)
 
 
 class Direction(Enum):

--- a/src/staldates/joystick.py
+++ b/src/staldates/joystick.py
@@ -102,13 +102,13 @@ class Zoom(Enum):
 def pan_speed_from_axis(axis):
     # Must return between 1 and 24 inclusive (0 when stopped)
     raw = abs(axis)
-    return math.ceil(24 * raw / 32767)
+    return 1 + math.ceil(23 * raw / 32767)
 
 
 def tilt_speed_from_axis(axis):
     # Must return between 1 and 20 inclusive (0 when stopped)
     raw = abs(axis)
-    return math.ceil(20 * raw / 32767)
+    return 1 + math.ceil(19 * raw / 32767)
 
 
 def zoom_speed_from_axis(axis):
@@ -149,6 +149,7 @@ class CameraJoystickAdapter(Thread):
 
         if (direction, pan_speed, tilt_speed) != self._last_sent_pan_tilt:
             self._last_sent_pan_tilt = (direction, pan_speed, tilt_speed)
+            print self._last_sent_pan_tilt
             getattr(self._camera, direction.value)(pan_speed, tilt_speed)
 
         zoom_dir = Zoom.from_axis(self._axes[3])
@@ -156,6 +157,7 @@ class CameraJoystickAdapter(Thread):
 
         if (zoom_dir, zoom_speed) != self._last_sent_zoom:
             self._last_sent_zoom = (zoom_dir, zoom_speed)
+            print self._last_sent_zoom
             if zoom_dir == Zoom.STOP:
                 self._camera.zoomStop()
             else:

--- a/src/staldates/joystick.py
+++ b/src/staldates/joystick.py
@@ -17,6 +17,7 @@ EVENT_SIZE = struct.calcsize(EVENT_FORMAT)
 class Joystick(Thread):
     def __init__(self, device):
         super(Joystick, self).__init__()
+        self.daemon = True
 
         self._axis_handlers = []
         self._button_handlers = []
@@ -121,6 +122,7 @@ def zoom_speed_from_axis(axis):
 class CameraJoystickAdapter(Thread):
     def __init__(self, js, map_pan=pan_speed_from_axis, map_tilt=tilt_speed_from_axis, map_zoom=zoom_speed_from_axis):
         super(CameraJoystickAdapter, self).__init__()
+        self.daemon = True
         if js:
             js.add_axis_handler(self._handle_axis)
         self._axes = [0, 0, 0, 0]

--- a/src/staldates/joystick.py
+++ b/src/staldates/joystick.py
@@ -64,7 +64,6 @@ class Direction(Enum):
 
     @staticmethod
     def from_axes(x, y, deadzone=0):
-        y = -1 * y
         if x > deadzone:
             if y > deadzone:
                 return Direction.UP_RIGHT

--- a/src/staldates/joystick.py
+++ b/src/staldates/joystick.py
@@ -1,0 +1,171 @@
+from enum import Enum
+from threading import Thread
+
+import math
+import struct
+import time
+from mock import MagicMock
+
+
+EVENT_BUTTON = 0x01  # button pressed/released
+EVENT_AXIS = 0x02  # axis moved
+EVENT_INIT = 0x80  # button/axis initialized
+EVENT_FORMAT = "IhBB"
+EVENT_SIZE = struct.calcsize(EVENT_FORMAT)
+
+
+class Joystick(Thread):
+    def __init__(self, device):
+        super(Joystick, self).__init__()
+
+        self._axis_handlers = []
+        self._button_handlers = []
+        self.device = open(device, 'r')
+
+    def add_axis_handler(self, handler):
+        self._axis_handlers.append(handler)
+
+    def add_button_handler(self, handler):
+        self._button_handlers.append(handler)
+
+    def _on_axis(self, axis, value):
+        for handler in self._axis_handlers:
+            handler(axis, value)
+
+    def _on_button(self, button, value):
+        for handler in self._button_handlers:
+            handler(button, value)
+
+    def run(self):
+        while True:
+            evt = self.device.read(EVENT_SIZE)
+            time, value, evt_type, number = struct.unpack(EVENT_FORMAT, evt)
+
+            if (evt_type & ~EVENT_INIT) == EVENT_AXIS:
+                # print "{} Axis {}: value {}".format(time, number, value)
+                self._on_axis(number, value)
+            elif (evt_type & ~EVENT_INIT) == EVENT_BUTTON:
+                # print "{} Button {}: value {}".format(time, number, value)
+                self._on_button(number, value)
+
+
+class Direction(Enum):
+    UP = "moveUp"
+    UP_RIGHT = "moveUpRight"
+    RIGHT = "moveRight"
+    DOWN_RIGHT = "moveDownRight"
+    DOWN = "moveDown"
+    DOWN_LEFT = "moveDownLeft"
+    LEFT = "moveLeft"
+    UP_LEFT = "moveUpLeft"
+    STOP = "stop"
+
+    @staticmethod
+    def from_axes(x, y, deadzone=0):
+        if x > deadzone:
+            if y > deadzone:
+                return Direction.UP_RIGHT
+            elif y < -1 * deadzone:
+                return Direction.DOWN_RIGHT
+            else:
+                return Direction.RIGHT
+        elif x < -1 * deadzone:
+            if y > deadzone:
+                return Direction.UP_LEFT
+            elif y < -1 * deadzone:
+                return Direction.DOWN_LEFT
+            else:
+                return Direction.LEFT
+        else:
+            if y > deadzone:
+                return Direction.UP
+            elif y < -1 * deadzone:
+                return Direction.DOWN
+            else:
+                return Direction.STOP
+
+
+class Zoom(Enum):
+    IN = "zoomIn"
+    OUT = "zoomOut"
+    STOP = "zoomStop"
+
+    @staticmethod
+    def from_axis(axis, deadzone=0):
+        if axis > deadzone:
+            return Zoom.OUT
+        elif axis < -1 * deadzone:
+            return Zoom.IN
+        return Zoom.STOP
+
+
+def pan_speed_from_axis(axis):
+    # Must return between 1 and 24 inclusive (0 when stopped)
+    raw = abs(axis)
+    return math.ceil(24 * raw / 32767)
+
+
+def tilt_speed_from_axis(axis):
+    # Must return between 1 and 20 inclusive (0 when stopped)
+    raw = abs(axis)
+    return math.ceil(20 * raw / 32767)
+
+
+def zoom_speed_from_axis(axis):
+    # Must return between 2 and 7 inclusive
+    raw = abs(axis)
+    return 2 + math.ceil(5 * raw / 32767)
+
+
+class CameraJoystickAdapter(Thread):
+    def __init__(self, js):
+        super(CameraJoystickAdapter, self).__init__()
+        js.add_axis_handler(self._handle_axis)
+        self._axes = [0, 0, 0, 0]
+        self.set_camera(None)
+
+    def set_camera(self, camera):
+        self._camera = camera
+        self._last_sent_pan_tilt = None
+        self._last_sent_zoom = None
+
+    def _handle_axis(self, axis, value):
+        if axis > 3:
+            return
+
+        self._axes[axis] = value
+
+    def run(self):
+        while True:
+            self._update_camera()
+            time.sleep(0.1)
+
+    def _update_camera(self):
+        if self._camera is None:
+            return
+        direction = Direction.from_axes(self._axes[0], self._axes[1])
+        pan_speed = pan_speed_from_axis(self._axes[0])
+        tilt_speed = tilt_speed_from_axis(self._axes[1])
+
+        if (direction, pan_speed, tilt_speed) != self._last_sent_pan_tilt:
+            self._last_sent_pan_tilt = (direction, pan_speed, tilt_speed)
+            getattr(self._camera, direction.value)(pan_speed, tilt_speed)
+
+        zoom_dir = Zoom.from_axis(self._axes[3])
+        zoom_speed = zoom_speed_from_axis(self._axes[3])
+
+        if (zoom_dir, zoom_speed) != self._last_sent_zoom:
+            self._last_sent_zoom = (zoom_dir, zoom_speed)
+            if zoom_dir == Zoom.STOP:
+                self._camera.zoomStop()
+            else:
+                getattr(self._camera, zoom_dir.value)(zoom_speed)
+
+
+if __name__ == "__main__":
+    dev_str = "/dev/input/js0"
+    js = Joystick(dev_str)
+    cja = CameraJoystickAdapter(js)
+    cja.set_camera(MagicMock())
+    js.start()
+    cja.start()

--- a/src/staldates/joystick.py
+++ b/src/staldates/joystick.py
@@ -118,10 +118,13 @@ def zoom_speed_from_axis(axis):
 
 
 class CameraJoystickAdapter(Thread):
-    def __init__(self, js):
+    def __init__(self, js, map_pan=pan_speed_from_axis, map_tilt=tilt_speed_from_axis, map_zoom=zoom_speed_from_axis):
         super(CameraJoystickAdapter, self).__init__()
         js.add_axis_handler(self._handle_axis)
         self._axes = [0, 0, 0, 0]
+        self.map_pan = map_pan
+        self.map_tilt = map_tilt
+        self.map_zoom = map_zoom
         self.set_camera(None)
 
     def set_camera(self, camera):
@@ -144,8 +147,8 @@ class CameraJoystickAdapter(Thread):
         if self._camera is None:
             return
         direction = Direction.from_axes(self._axes[0], self._axes[1])
-        pan_speed = pan_speed_from_axis(self._axes[0])
-        tilt_speed = tilt_speed_from_axis(self._axes[1])
+        pan_speed = self.map_pan(self._axes[0])
+        tilt_speed = self.map_tilt(self._axes[1])
 
         if (direction, pan_speed, tilt_speed) != self._last_sent_pan_tilt:
             self._last_sent_pan_tilt = (direction, pan_speed, tilt_speed)
@@ -153,7 +156,7 @@ class CameraJoystickAdapter(Thread):
             getattr(self._camera, direction.value)(pan_speed, tilt_speed)
 
         zoom_dir = Zoom.from_axis(self._axes[3])
-        zoom_speed = zoom_speed_from_axis(self._axes[3])
+        zoom_speed = self.map_zoom(self._axes[3])
 
         if (zoom_dir, zoom_speed) != self._last_sent_zoom:
             self._last_sent_zoom = (zoom_dir, zoom_speed)

--- a/src/staldates/tests/TestJoystick.py
+++ b/src/staldates/tests/TestJoystick.py
@@ -1,4 +1,4 @@
-from staldates.joystick import Joystick, Direction, Zoom
+from staldates.joystick import Joystick, Direction, Zoom, CameraJoystickAdapter
 
 import unittest
 import struct
@@ -71,3 +71,49 @@ class TestJoystick(unittest.TestCase):
             (1, Zoom.IN)
         ]:
             do_test(z, expected)
+
+
+class TestCameraJoystickAdapter(unittest.TestCase):
+    def testHandlesAxes(self):
+        camera = MagicMock()
+
+        cja = CameraJoystickAdapter(None)
+        cja.set_camera(camera)
+
+        cja._handle_axis(1, -32768)
+        cja._update_camera()
+        camera.moveDown.assert_called_once_with(1, 20)
+
+        cja._handle_axis(1, 32767)
+        cja._update_camera()
+        camera.moveUp.assert_called_once_with(1, 20)
+
+        cja._handle_axis(1, 0)
+        cja._update_camera()
+        camera.stop.assert_called_once()
+
+        camera.reset_mock()
+
+        cja._handle_axis(0, 1)
+        cja._update_camera()
+        camera.moveRight.assert_called_once_with(1, 1)
+
+        cja._handle_axis(0, -1)
+        cja._update_camera()
+        camera.moveLeft.assert_called_once_with(1, 1)
+
+        cja._handle_axis(0, 0)
+        cja._update_camera()
+        camera.stop.assert_called_once()
+
+        cja._handle_axis(3, -32768)
+        cja._update_camera()
+        camera.zoomOut.assert_called_once_with(7)
+
+        cja._handle_axis(3, 32767)
+        cja._update_camera()
+        camera.zoomIn.assert_called_once_with(7)
+
+        cja._handle_axis(3, 0)
+        cja._update_camera()
+        camera.zoomStop.assert_called_once()

--- a/src/staldates/tests/TestJoystick.py
+++ b/src/staldates/tests/TestJoystick.py
@@ -1,0 +1,73 @@
+from staldates.joystick import Joystick, Direction, Zoom
+
+import unittest
+import struct
+from mock import MagicMock
+
+
+EVENT_FORMAT = "IhBB"
+EVENT_SIZE = struct.calcsize(EVENT_FORMAT)
+
+
+class TestJoystick(unittest.TestCase):
+    def testEventParsing(self):
+        js = Joystick('/dev/null')
+
+        button_handler = MagicMock()
+        axis_handler = MagicMock()
+
+        js.add_axis_handler(axis_handler)
+        js.add_button_handler(button_handler)
+
+        evtBtn1Press = struct.pack(EVENT_FORMAT, 1138, 1, 0x01, 1)
+        js.parse_event(evtBtn1Press)
+        button_handler.assert_called_once_with(1, 1)
+        button_handler.reset_mock()
+
+        evtBtn1Release = struct.pack(EVENT_FORMAT, 1138, 0, 0x01, 1)
+        js.parse_event(evtBtn1Release)
+        button_handler.assert_called_once_with(1, 0)
+        button_handler.reset_mock()
+
+        evtAxis1 = struct.pack(EVENT_FORMAT, 1138, 12345, 0x02, 1)
+        js.parse_event(evtAxis1)
+        axis_handler.assert_called_once_with(1, 12345)
+        axis_handler.reset_mock()
+
+        evtAxis3 = struct.pack(EVENT_FORMAT, 1138, -15432, 0x02, 3)
+        js.parse_event(evtAxis3)
+        axis_handler.assert_called_once_with(3, -15432)
+        axis_handler.reset_mock()
+
+    def testDirection(self):
+        def do_test(x, y, expected):
+            direction = Direction.from_axes(x, y)
+            self.assertEqual(expected, direction)
+
+        for x, y, expected in [
+            (0, 0, Direction.STOP),
+            (0, 1, Direction.UP),
+            (1, 1, Direction.UP_RIGHT),
+            (1, 0, Direction.RIGHT),
+            (1, -1, Direction.DOWN_RIGHT),
+            (0, -1, Direction.DOWN),
+            (-1, -1, Direction.DOWN_LEFT),
+            (-1, 0, Direction.LEFT),
+            (-1, 1, Direction.UP_LEFT),
+        ]:
+            do_test(x, y, expected)
+
+        # Test deadzone
+        self.assertEqual(Direction.STOP, Direction.from_axes(10, 10, 10))
+
+    def testZoom(self):
+        def do_test(z, expected):
+            zoom = Zoom.from_axis(z)
+            self.assertEqual(expected, zoom)
+
+        for z, expected in [
+            (0, Zoom.STOP),
+            (-1, Zoom.OUT),
+            (1, Zoom.IN)
+        ]:
+            do_test(z, expected)

--- a/src/staldates/ui/MainWindow.py
+++ b/src/staldates/ui/MainWindow.py
@@ -20,7 +20,7 @@ from avx.devices.net.hyperdeck import TransportState
 
 class MainWindow(QMainWindow):
 
-    def __init__(self, controller):
+    def __init__(self, controller, joystickAdapter=None):
         super(MainWindow, self).__init__()
         self.controller = controller
 
@@ -31,7 +31,7 @@ class MainWindow(QMainWindow):
         atem = controller['ATEM']
         self.switcherState = SwitcherState(atem)
 
-        self.mainScreen = VideoSwitcher(controller, self, self.switcherState)
+        self.mainScreen = VideoSwitcher(controller, self, self.switcherState, joystickAdapter)
 
         # This is possibly a bad / too complicated idea...
         # self.mainScreen.setEnabled(self.switcherState.connected)

--- a/src/staldates/ui/VideoSwitcher.py
+++ b/src/staldates/ui/VideoSwitcher.py
@@ -33,6 +33,10 @@ class VideoSwitcher(QWidget):
                 return func()
             return (None, None, None, None)
 
+        def setCamera(cam):
+            if self.joystickAdapter:
+                self.joystickAdapter.set_camera(cam)
+
         def makeCamera(videoSource, cameraID):
             cam = self.controller[cameraID]
 
@@ -40,11 +44,12 @@ class VideoSwitcher(QWidget):
                 videoSource,
                 CameraControl(cam),
                 AdvancedCameraControl(cameraID, cam, self.mainWindow),
-                lambda: self.joystickAdapter.set_camera(cam)
+                lambda: setCamera(cam)
             )
 
         def deselectCamera():
-            self.joystickAdapter.set_camera(None)
+            if self.joystickAdapter:
+                self.joystickAdapter.set_camera(None)
 
         self.input_buttons_config = [
             ifDevice("Camera 1", lambda: makeCamera(VideoSource.INPUT_1, "Camera 1")),

--- a/src/staldates/ui/tests/TestErrorHandling.py
+++ b/src/staldates/ui/tests/TestErrorHandling.py
@@ -1,0 +1,46 @@
+from PySide import QtCore, QtGui
+from staldates.ui.tests.GuiTest import GuiTest
+from staldates.ui.widgets.Dialogs import handlePyroErrors
+
+import Pyro4
+
+
+class TestErrorHandling(GuiTest):
+
+    def _testDialogShowsWithText(self, func, dialog_text):
+        def assert_about_dialog(dia):
+            self.assertFalse(dia.isHidden())
+            self.assertTrue(dia.text().startswith("<span style=\"color: white;\">{}".format(dialog_text)), "Dialog text was {}, expected {}".format(dia.text(), dialog_text))
+            return True
+
+        def close_dialog():
+            found_dialog = False
+            for tlw in self.app.topLevelWidgets():
+                if tlw.__class__ == QtGui.QMessageBox:
+                    found_dialog = True
+                    try:
+                        self.test_result = assert_about_dialog(tlw)
+                    finally:
+                        tlw.accept()
+            self.assertTrue(found_dialog)
+
+        t = QtCore.QTimer()
+        t.timeout.connect(close_dialog)
+        t.start(0.5)
+
+        self.test_result = False
+
+        func()
+
+        self.assertTrue(self.test_result, "Test failed, see earlier output for details.")
+
+    def testHandlePyroErrors(self):
+        def timeout():
+            raise Pyro4.errors.TimeoutError()
+
+        def comms():
+            raise Pyro4.errors.CommunicationError()
+
+        self._testDialogShowsWithText(handlePyroErrors(timeout), "Communication with the controller timed out.")
+        self._testDialogShowsWithText(handlePyroErrors(comms), "(CommunicationError)")
+        self._testDialogShowsWithText(handlePyroErrors(comms, "Extra message"), "Extra message")


### PR DESCRIPTION
This PR adds the ability to use a connected joystick to control pan, tilt and zoom of cameras.

The joystick device should be specified with the `-j` or `--joystick` command-line option to `avcontrol.py`.

Default mappings from axis values to VISCA speeds are linear and can be overridden by providing `map_pan`, `map_tilt` and/or `map_zoom` functions to the `CameraJoystickAdapter` constructor. These functions should always return legal VISCA speed values (e.g `1 <= retval <= VISCA_MAX`) even when zero pan or tilt is required. It's likely that we'll want to change the defaults to something nonlinear as the default functions make the joystick somewhat sensitive.

Closes #4. Relates to (and possibly obsoletes?) #20.