### PR TITLE
Changes supporting running church from an aux

### DIFF
--- a/src/staldates/VisualsSystem.py
+++ b/src/staldates/VisualsSystem.py
@@ -85,10 +85,10 @@ class Output(QObject):
 
 def _default_outputs():
     return {
-        0: Output("Record", VideoSource.AUX_1),
-        1: Output("Stage", VideoSource.AUX_2),
-        2: Output("Gallery", VideoSource.AUX_3),
-        3: Output("Aux 4", VideoSource.AUX_4),
+        0: Output("Church", VideoSource.AUX_1),
+        1: Output("Record", VideoSource.AUX_2),
+        2: Output("Stage", VideoSource.AUX_3),
+        3: Output("Gallery", VideoSource.AUX_4),
         4: Output("Aux 5", VideoSource.AUX_5),
         5: Output("Aux 6", VideoSource.AUX_6),
     }

--- a/src/staldates/VisualsSystem.py
+++ b/src/staldates/VisualsSystem.py
@@ -54,6 +54,7 @@ def _default_inputs():
         (VideoSource.INPUT_5, "Visuals PC", QIcon(":icons/computer")),
         (VideoSource.INPUT_6, "PC Video", QIcon(":icons/video-display")),
         (VideoSource.BLACK, "Black", QIcon(":icons/blackscreen")),
+        (VideoSource.ME_1_PROGRAM, "Main mix", None),
     ]}
 
 

--- a/src/staldates/ui/VideoSwitcher.py
+++ b/src/staldates/ui/VideoSwitcher.py
@@ -115,6 +115,8 @@ class VideoSwitcher(QWidget):
         self.og.all.connect(self.sendToAll)
         self.og.sendMain.connect(self.sendMainToAux)
 
+        self.og.setAuxesEnabled(False)  # since we start off without an input selected
+
         layout.addWidget(self.og, 1, 5, 1, 2)
 
         self.blankWidget = QWidget()

--- a/src/staldates/ui/VideoSwitcher.py
+++ b/src/staldates/ui/VideoSwitcher.py
@@ -113,6 +113,7 @@ class VideoSwitcher(QWidget):
         self.og.selected.connect(self.sendToAux)
         self.og.mainToAll.connect(self.sendMainToAllAuxes)
         self.og.all.connect(self.sendToAll)
+        self.og.sendMain.connect(self.sendMainToAux)
 
         layout.addWidget(self.og, 1, 5, 1, 2)
 
@@ -158,6 +159,10 @@ class VideoSwitcher(QWidget):
             self.atem.setProgram(self.inputs.checkedButton().input.source)
             for aux in self.switcherState.outputs.keys():
                 self.sendToAux(aux)
+
+    @with_atem
+    def sendMainToAux(self, auxIndex):
+        self.atem.setAuxSource(auxIndex + 1, VideoSource.ME_1_PROGRAM)
 
     @with_atem
     def sendMainToAllAuxes(self):

--- a/src/staldates/ui/resources/AldatesX.qss
+++ b/src/staldates/ui/resources/AldatesX.qss
@@ -11,8 +11,14 @@ OutputsGrid {
   background-color: #00527E;
 }
 
-OutputsGrid > QFrame {
-  background-color: #E4E4FF;
+MainMixControl {
+  border: 2px outset #E4E4FF;
+  border-radius: 5px;
+}
+
+MainMixControl > QLabel {
+  text-align: center;
+  font-size: 12pt;
 }
 
 InputButton, OutputButton, OptionButton, ExpandingButton, QComboBox, QListView {
@@ -21,6 +27,11 @@ InputButton, OutputButton, OptionButton, ExpandingButton, QComboBox, QListView {
   border-radius: 5px;
   border: none;
   selection-background-color: #003E5F;
+}
+
+ExpandingButton.mainMix {
+  background-color: #E4E4FF;
+  color: black;
 }
 
 ExpandingButton:pressed, ExpandingButton:checked {
@@ -32,8 +43,21 @@ InputButton:disabled, OutputButton:disabled, OptionButton:disabled, ExpandingBut
   background-color: #9FA5A5;
 }
 
-OutputButton>QLabel {
+OutputButton {
+  color: #1693A5;
+}
+
+OutputButton:pressed {
+  color: #E4E4FF;
+}
+
+OutputButton>#stateDisplay {
   font-size: 12pt;
+}
+
+OutputButton>#stateDisplay[highlight="true"] {
+  background-color: #E4E4FF;
+  color: black;
 }
 
 QToolButton[isPreview="true"] {

--- a/src/staldates/ui/resources/AldatesX.qss
+++ b/src/staldates/ui/resources/AldatesX.qss
@@ -53,6 +53,7 @@ OutputButton:pressed {
 
 OutputButton>#stateDisplay {
   font-size: 12pt;
+  border-radius: 5px;
 }
 
 OutputButton>#stateDisplay[highlight="true"] {

--- a/src/staldates/ui/resources/AldatesX.qss
+++ b/src/staldates/ui/resources/AldatesX.qss
@@ -47,6 +47,10 @@ OutputButton {
   color: #1693A5;
 }
 
+OutputButton:disabled {
+  color: #9FA5A5;
+}
+
 OutputButton:pressed {
   color: #E4E4FF;
 }

--- a/src/staldates/ui/tests/TestVideoSwitcher.py
+++ b/src/staldates/ui/tests/TestVideoSwitcher.py
@@ -91,11 +91,11 @@ class TestVideoSwitcher(GuiTest):
         self.atem.setAuxSource.reset_mock()
         self.findButton(vs, "Visuals PC").click()
         self.findButton(vs.og, "Record").click()
-        self.atem.setAuxSource.assert_called_once_with(1, VideoSource.INPUT_5)
+        self.atem.setAuxSource.assert_called_once_with(2, VideoSource.INPUT_5)
         self.atem.setAuxSource.reset_mock()
 
         self.findButton(vs.og, "Record").longpress.emit()
-        self.atem.setAuxSource.assert_called_once_with(1, VideoSource.ME_1_PROGRAM)
+        self.atem.setAuxSource.assert_called_once_with(2, VideoSource.ME_1_PROGRAM)
         self.atem.setAuxSource.reset_mock()
 
         self.findButton(vs.og, "Mix to all").click()

--- a/src/staldates/ui/tests/TestVideoSwitcher.py
+++ b/src/staldates/ui/tests/TestVideoSwitcher.py
@@ -94,7 +94,7 @@ class TestVideoSwitcher(GuiTest):
         self.atem.setAuxSource.assert_called_once_with(1, VideoSource.INPUT_5)
 
         self.atem.setAuxSource.reset_mock()
-        self.findButton(vs.og, "Main to\nall auxes").click()
+        self.findButton(vs.og, "Mix to all").click()
         self.atem.setAuxSource.assert_has_calls([
             call(1, VideoSource.ME_1_PROGRAM),
             call(2, VideoSource.ME_1_PROGRAM),

--- a/src/staldates/ui/tests/TestVideoSwitcher.py
+++ b/src/staldates/ui/tests/TestVideoSwitcher.py
@@ -52,9 +52,11 @@ class TestVideoSwitcher(GuiTest):
         all_inputs = extrasBtn.property("panel")
         self.assertTrue(isinstance(all_inputs, AllInputsPanel))
 
+        vs.og.setAuxesEnabled(True)  # as if we'd selected something before
+        self.assertTrue(self.findButton(vs, "All").isEnabled())  # Before we click Extras, All button is enabled
+
         self.assertTrue(extrasBtn.input is None)  # At first, it has no input
         self.assertTrue(self.findButton(vs, "Camera 1") is None)  # No button for Camera 1 in window
-        self.assertTrue(self.findButton(vs, "All").isEnabled())  # Before we click Extras, All button is enabled
 
         extrasBtn.click()
 

--- a/src/staldates/ui/tests/TestVideoSwitcher.py
+++ b/src/staldates/ui/tests/TestVideoSwitcher.py
@@ -92,8 +92,12 @@ class TestVideoSwitcher(GuiTest):
         self.findButton(vs, "Visuals PC").click()
         self.findButton(vs.og, "Record").click()
         self.atem.setAuxSource.assert_called_once_with(1, VideoSource.INPUT_5)
-
         self.atem.setAuxSource.reset_mock()
+
+        self.findButton(vs.og, "Record").longpress.emit()
+        self.atem.setAuxSource.assert_called_once_with(1, VideoSource.ME_1_PROGRAM)
+        self.atem.setAuxSource.reset_mock()
+
         self.findButton(vs.og, "Mix to all").click()
         self.atem.setAuxSource.assert_has_calls([
             call(1, VideoSource.ME_1_PROGRAM),

--- a/src/staldates/ui/widgets/Buttons.py
+++ b/src/staldates/ui/widgets/Buttons.py
@@ -110,12 +110,9 @@ class IDedButton(ExpandingButton):
 
 class OutputButton(ExpandingButton):
 
-    longpress = Signal()
-
     def __init__(self, myOutput, parent=None):
         super(OutputButton, self).__init__(parent)
         self.setToolButtonStyle(Qt.ToolButtonStyle.ToolButtonIconOnly)  # Sneakily hide our actual text
-        self.grabGesture(Qt.TapAndHoldGesture)
 
         self.textDisplay = QLabel()
         self.stateDisplay = QLabel()

--- a/src/staldates/ui/widgets/Buttons.py
+++ b/src/staldates/ui/widgets/Buttons.py
@@ -113,13 +113,20 @@ class OutputButton(ExpandingButton):
 
     def __init__(self, myOutput, parent=None):
         super(OutputButton, self).__init__(parent)
-        self.setToolButtonStyle(Qt.ToolButtonStyle.ToolButtonTextUnderIcon)
+        self.setToolButtonStyle(Qt.ToolButtonStyle.ToolButtonIconOnly)  # Sneakily hide our actual text
         self.grabGesture(Qt.TapAndHoldGesture)
 
+        self.textDisplay = QLabel()
         self.stateDisplay = QLabel()
         layout = QVBoxLayout()
+        layout.addWidget(self.textDisplay)
         layout.addWidget(self.stateDisplay)
-        layout.setAlignment(Qt.AlignBottom | Qt.AlignHCenter)
+
+        self.textDisplay.setObjectName("textDisplay")
+
+        self.stateDisplay.setObjectName("stateDisplay")
+        self.stateDisplay.setAlignment(Qt.AlignHCenter)
+
         self.setLayout(layout)
 
         self.output = myOutput
@@ -133,6 +140,10 @@ class OutputButton(ExpandingButton):
             self.stateDisplay.setText(self.output.source.label)
         else:
             self.stateDisplay.setText("-")
+
+    def setText(self, text):
+        self.textDisplay.setText(text)
+        super(OutputButton, self).setText(text)
 
 
 class OptionButton(ExpandingButton):

--- a/src/staldates/ui/widgets/Buttons.py
+++ b/src/staldates/ui/widgets/Buttons.py
@@ -1,3 +1,4 @@
+from avx.devices.net.atem.constants import VideoSource
 from PySide.QtGui import QLabel, QToolButton, QSizePolicy, QVBoxLayout, QImage,\
     QPainter, QPixmap, QIcon
 from PySide.QtCore import Qt, QSize, Signal, QEvent, QTimer
@@ -138,8 +139,12 @@ class OutputButton(ExpandingButton):
 
         if self.output.source and hasattr(self.output.source, "label"):
             self.stateDisplay.setText(self.output.source.label)
+            self.stateDisplay.setProperty("highlight", (self.output.source.source != VideoSource.ME_1_PROGRAM))
         else:
             self.stateDisplay.setText("-")
+            self.stateDisplay.setProperty("highlight", False)
+        self.stateDisplay.style().unpolish(self.stateDisplay)
+        self.stateDisplay.style().polish(self.stateDisplay)
 
     def setText(self, text):
         self.textDisplay.setText(text)

--- a/src/staldates/ui/widgets/OutputsGrid.py
+++ b/src/staldates/ui/widgets/OutputsGrid.py
@@ -37,11 +37,13 @@ class OutputsGrid(QFrame):
     mainToAll = Signal()
     all = Signal()
     selected = Signal(int)
+    sendMain = Signal(int)
 
     def __init__(self, switcherState, parent=None):
         super(OutputsGrid, self).__init__(parent)
 
         self.signalMapper = QSignalMapper(self)
+        self.longPressSignalMapper = QSignalMapper(self)
 
         layout = QGridLayout()
 
@@ -58,9 +60,13 @@ class OutputsGrid(QFrame):
             layout.addWidget(ob, 1 + (idx / 2), idx % 2)
             ob.clicked.connect(self.signalMapper.map)
             self.signalMapper.setMapping(ob, idx)
+
+            ob.longpress.connect(self.longPressSignalMapper.map)
+            self.longPressSignalMapper.setMapping(ob, idx)
             self.aux_buttons.append(ob)
 
         self.signalMapper.mapped.connect(self.registerClick)
+        self.longPressSignalMapper.mapped.connect(self.longPress)
 
         btnAll = ExpandingButton()
         btnAll.setProperty("class", "mainMix")
@@ -86,6 +92,9 @@ class OutputsGrid(QFrame):
 
     def registerClick(self, idx):
         self.selected.emit(idx)
+
+    def longPress(self, idx):
+        self.sendMain.emit(idx)
 
     def setAuxesEnabled(self, enabled):
         for button in self.aux_buttons:

--- a/src/staldates/ui/widgets/OutputsGrid.py
+++ b/src/staldates/ui/widgets/OutputsGrid.py
@@ -1,6 +1,33 @@
-from PySide.QtGui import QFrame, QGridLayout, QHBoxLayout
+from PySide.QtGui import QFrame, QGridLayout, QLabel
 from staldates.ui.widgets.Buttons import OutputButton, ExpandingButton
-from PySide.QtCore import Signal, QSignalMapper
+from PySide.QtCore import Signal, QSignalMapper, Qt
+
+
+class MainMixControl(QFrame):
+    cut = Signal()
+    take = Signal()
+
+    def __init__(self, parent=None):
+        super(MainMixControl, self).__init__(parent)
+        layout = QGridLayout()
+
+        label = QLabel('Main mix', None)
+        label.setAlignment(Qt.AlignHCenter)
+        layout.addWidget(label, 0, 0, 1, 2)
+
+        btnTake = ExpandingButton()
+        btnTake.setProperty("class", "mainMix")
+        btnTake.setText("Cut")
+        btnTake.clicked.connect(self.cut.emit)
+        layout.addWidget(btnTake, 1, 0)
+
+        btnFade = ExpandingButton()
+        btnFade.setProperty("class", "mainMix")
+        btnFade.setText("Fade")
+        btnFade.clicked.connect(self.take.emit)
+        layout.addWidget(btnFade, 1, 1)
+
+        self.setLayout(layout)
 
 
 class OutputsGrid(QFrame):
@@ -18,21 +45,11 @@ class OutputsGrid(QFrame):
 
         layout = QGridLayout()
 
-        pgmButtonFrame = QFrame()
-        pgmLayout = QHBoxLayout()
+        mainMixFrame = MainMixControl()
+        mainMixFrame.cut.connect(self.cut.emit)
+        mainMixFrame.take.connect(self.take.emit)
 
-        btnTake = ExpandingButton()
-        btnTake.setText("Cut")
-        btnTake.clicked.connect(self.cut.emit)
-        pgmLayout.addWidget(btnTake)
-
-        btnFade = ExpandingButton()
-        btnFade.setText("Fade")
-        btnFade.clicked.connect(self.take.emit)
-        pgmLayout.addWidget(btnFade)
-
-        pgmButtonFrame.setLayout(pgmLayout)
-        layout.addWidget(pgmButtonFrame, 0, 0, 1, 2)
+        layout.addWidget(mainMixFrame, 0, 0, 1, 2)
 
         self.aux_buttons = []
 
@@ -45,10 +62,11 @@ class OutputsGrid(QFrame):
 
         self.signalMapper.mapped.connect(self.registerClick)
 
-        btnMainToAll = ExpandingButton()
-        btnMainToAll.setText("Main to\nall auxes")
-        btnMainToAll.clicked.connect(self.mainToAll.emit)
-        layout.addWidget(btnMainToAll, 4, 0)
+        btnAll = ExpandingButton()
+        btnAll.setProperty("class", "mainMix")
+        btnAll.setText("Mix to all")
+        btnAll.clicked.connect(self.mainToAll.emit)
+        layout.addWidget(btnAll, 4, 0)
 
         self.btnAll = ExpandingButton()
         self.btnAll.setText("All")
@@ -59,6 +77,10 @@ class OutputsGrid(QFrame):
         layout.setColumnMinimumWidth(1, 100)
         layout.setColumnStretch(0, 1)
         layout.setColumnStretch(1, 1)
+
+        layout.setRowStretch(0, 2)
+        for i in range(1, 5):
+            layout.setRowStretch(i, 1)
 
         self.setLayout(layout)
 

--- a/src/staldates/ui/widgets/tests/TestButtons.py
+++ b/src/staldates/ui/widgets/tests/TestButtons.py
@@ -1,7 +1,7 @@
 from staldates.ui.tests.GuiTest import GuiTest
-from staldates.VisualsSystem import Input
+from staldates.VisualsSystem import Input, Output
 from avx.devices.net.atem.constants import VideoSource
-from staldates.ui.widgets.Buttons import InputButton
+from staldates.ui.widgets.Buttons import InputButton, OutputButton
 
 
 class TestButtons(GuiTest):
@@ -33,3 +33,23 @@ class TestButtons(GuiTest):
         my_input.set_preview(False)
         self.assertFalse(ib.property("isLive"))
         self.assertFalse(ib.property("isPreview"))
+
+    def testOutputButton(self):
+        some_input = Input(VideoSource.INPUT_1, "My input", None)
+        main_mix = Input(VideoSource.ME_1_PROGRAM, "Main mix", None)
+
+        my_output = Output("Some Output", VideoSource.AUX_1)
+
+        ob = OutputButton(my_output)
+        ob_state = ob.stateDisplay
+
+        self.assertEqual('-', ob_state.text())
+        self.assertFalse(ob_state.property("highlight"))
+
+        my_output.set_source(some_input)
+        self.assertEqual('My input', ob_state.text())
+        self.assertTrue(ob_state.property("highlight"))
+
+        my_output.set_source(main_mix)
+        self.assertEqual('Main mix', ob_state.text())
+        self.assertFalse(ob_state.property("highlight"))

--- a/src/staldates/ui/widgets/tests/TestOutputsGrid.py
+++ b/src/staldates/ui/widgets/tests/TestOutputsGrid.py
@@ -54,7 +54,7 @@ class TestOutputsGrid(GuiTest):
         mainToAllHandler = MagicMock()
         og.mainToAll.connect(mainToAllHandler)
 
-        btn = self.findButton(og, "Main to\nall auxes")
+        btn = self.findButton(og, "Mix to all")
         self.assertTrue(btn is not None)
         btn.click()
         mainToAllHandler.assert_called_once_with()


### PR DESCRIPTION
This PR contains the code changes discussed in #22, to support driving the church screens from an aux output rather than hard-wiring it to `M/E 1 PGM`.

For reference, the UI now looks like this: https://imgur.com/a/WoX2a - see individual commits for my reasoning behind the changes.