### PR TITLE
Add joystick control preferences

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
     author='James Muscat',
     author_email='jamesremuscat@gmail.com',
     url='https://github.com/staldates/av-control',
-    install_requires=['avx>=1.1.0rc1', "Pyro4>=4.20,!=4.45", 'PySide'],
+    install_requires=['avx>=1.1.0rc1', "Pyro4>=4.20,!=4.45", 'PySide', 'simplejson'],
     setup_requires=['nose>=1.0'],
     tests_require = ['mock'],
     packages=find_packages('src', exclude=["*.tests"]),

--- a/src/staldates/avcontrol.py
+++ b/src/staldates/avcontrol.py
@@ -14,7 +14,7 @@ from staldates.ui import resources  # @UnusedImport  # Initialises the Qt resour
 from staldates.ui.MainWindow import MainWindow
 from staldates.ui.widgets import Dialogs
 from staldates.ui.widgets.Dialogs import handlePyroErrors
-from staldates.joystick import Joystick, CameraJoystickAdapter
+from staldates.joystick import Joystick, SensitivityPrefsCameraJoystickAdapter
 
 
 Pyro4.config.COMMTIMEOUT = 3  # seconds
@@ -115,7 +115,7 @@ def main():
             logging.exception("Unable to configure joystick")
             pass
 
-        jsa = CameraJoystickAdapter(js)
+        jsa = SensitivityPrefsCameraJoystickAdapter(js)
         jsa.start()
         myapp = MainWindow(controller, jsa)
 

--- a/src/staldates/joystick.py
+++ b/src/staldates/joystick.py
@@ -125,7 +125,7 @@ def zoom_speed_from_axis(axis):
     return int(2 + math.ceil(5 * raw / 32767))
 
 
-PREFS_INVERT_Y = 'joystick.invert_y'
+PREFS_INVERT_Y = 'joystick_invert_y'
 
 
 class CameraJoystickAdapter(Thread):

--- a/src/staldates/joystick.py
+++ b/src/staldates/joystick.py
@@ -125,7 +125,7 @@ def zoom_speed_from_axis(axis):
     return int(2 + math.ceil(5 * raw / 32767))
 
 
-PREFS_INVERT_Y = 'joystick_invert_y'
+PREFS_INVERT_Y = 'joystick.invert_y'
 
 
 class CameraJoystickAdapter(Thread):

--- a/src/staldates/joystick.py
+++ b/src/staldates/joystick.py
@@ -140,6 +140,7 @@ class CameraJoystickAdapter(Thread):
         self.map_zoom = map_zoom
         self.set_camera(None)
         self.set_on_move(None)
+        self.update_preferences()
         Preferences.subscribe(self.update_preferences)
 
     def update_preferences(self):

--- a/src/staldates/joystick.py
+++ b/src/staldates/joystick.py
@@ -107,37 +107,16 @@ class Zoom(Enum):
         return Zoom.STOP
 
 
-def pan_speed_from_axis(axis):
-    # Must return between 1 and 24 inclusive (0 when stopped)
-    raw = abs(axis)
-    return int(1 + math.ceil(23 * raw / 32767))
-
-
-def tilt_speed_from_axis(axis):
-    # Must return between 1 and 20 inclusive (0 when stopped)
-    raw = abs(axis)
-    return int(1 + math.ceil(19 * raw / 32767))
-
-
-def zoom_speed_from_axis(axis):
-    # Must return between 2 and 7 inclusive
-    raw = abs(axis)
-    return int(2 + math.ceil(5 * raw / 32767))
-
-
 PREFS_INVERT_Y = 'joystick.invert_y'
 
 
 class CameraJoystickAdapter(Thread):
-    def __init__(self, js, map_pan=pan_speed_from_axis, map_tilt=tilt_speed_from_axis, map_zoom=zoom_speed_from_axis):
+    def __init__(self, js):
         super(CameraJoystickAdapter, self).__init__()
         self.daemon = True
         if js:
             js.add_axis_handler(self._handle_axis)
         self._axes = [0, 0, 0, 0]
-        self.map_pan = map_pan
-        self.map_tilt = map_tilt
-        self.map_zoom = map_zoom
         self.set_camera(None)
         self.set_on_move(None)
         self.update_preferences()
@@ -168,6 +147,21 @@ class CameraJoystickAdapter(Thread):
         while True:
             self._update_camera()
             time.sleep(0.1)
+
+    def map_pan(self, axis):
+        """Should return a value between 1 and 24 inclusive."""
+        raw = abs(axis)
+        return int(1 + math.ceil(23 * raw / 32767))
+
+    def map_tilt(self, axis):
+        """Should return a value between 1 and 20 inclusive."""
+        raw = abs(axis)
+        return int(1 + math.ceil(19 * raw / 32767))
+
+    def map_zoom(self, axis):
+        """Should return a value between 2 and 7 inclusive."""
+        raw = abs(axis)
+        return int(2 + math.ceil(5 * raw / 32767))
 
     def _update_camera(self):
         if self._camera is None:

--- a/src/staldates/joystick.py
+++ b/src/staldates/joystick.py
@@ -217,15 +217,16 @@ class SensitivityPrefsCameraJoystickAdapter(CameraJoystickAdapter):
             self.min_zoom = 2
             self.max_zoom = 7
 
-        self.pan_sensitivity = Preferences.get('joystick.sensitivity.pan', math.ceil(self.max_pan / 2))
-        self.tilt_sensitivity = Preferences.get('joystick.sensitivity.tilt', math.ceil(self.max_tilt / 2))
-        self.zoom_sensitivity = Preferences.get('joystick.sensitivity.zoom', math.ceil(self.max_zoom / 2))
+        self.pan_sensitivity = Preferences.get('joystick.sensitivity.pan', 0.5)
+        self.tilt_sensitivity = Preferences.get('joystick.sensitivity.tilt', 0.5)
+        self.zoom_sensitivity = Preferences.get('joystick.sensitivity.zoom', 0.5)
 
     def _interp(self, raw, max_value, sensitivity):
+        sensitivity_value = math.ceil(max_value * sensitivity)
         if raw <= JOYSTICK_HALF:
-            return int(1 + math.ceil(sensitivity * raw / JOYSTICK_HALF))
+            return max(1, int(math.ceil(sensitivity_value * raw / JOYSTICK_HALF)))
         else:
-            return int(1 + sensitivity + (2 * (raw - JOYSTICK_HALF) * (max_value - sensitivity) / JOYSTICK_MAX))
+            return max(1, int(sensitivity_value + math.ceil((2 * (raw - JOYSTICK_HALF) * (max_value - sensitivity_value) / JOYSTICK_MAX))))
 
     def map_pan(self, axis):
         return self._interp(abs(axis), self.max_pan, self.pan_sensitivity)
@@ -234,7 +235,7 @@ class SensitivityPrefsCameraJoystickAdapter(CameraJoystickAdapter):
         return self._interp(abs(axis), self.max_tilt, self.tilt_sensitivity)
 
     def map_zoom(self, axis):
-        return self.min_zoom + self._interp(abs(axis), self.max_zoom - self.min_zoom, self.zoom_sensitivity)
+        return max(self.min_zoom, self._interp(abs(axis), self.max_zoom, self.zoom_sensitivity))
 
 
 if __name__ == "__main__":

--- a/src/staldates/joystick.py
+++ b/src/staldates/joystick.py
@@ -241,10 +241,3 @@ class SensitivityPrefsCameraJoystickAdapter(CameraJoystickAdapter):
 
     def map_zoom(self, axis):
         return max(self.min_zoom, self._interp(abs(axis), self.max_zoom, self.zoom_sensitivity))
-
-
-if __name__ == "__main__":
-
-    j = SensitivityPrefsCameraJoystickAdapter(None)
-    for i in range(0, JOYSTICK_MAX, 100):
-        print "{},{},{},{}".format(i, j.map_pan(i), j.map_tilt(i), j.map_zoom(i))

--- a/src/staldates/joystick.py
+++ b/src/staldates/joystick.py
@@ -196,7 +196,19 @@ JOYSTICK_MAX = 32767
 JOYSTICK_HALF = JOYSTICK_MAX / 2
 
 
+def _linear_interp(raw, max_value, sensitivity):
+    sensitivity_value = math.ceil(max_value * sensitivity)
+    if raw <= JOYSTICK_HALF:
+        return max(1, int(math.ceil(sensitivity_value * raw / JOYSTICK_HALF)))
+    else:
+        return max(1, int(sensitivity_value + math.ceil((2 * (raw - JOYSTICK_HALF) * (max_value - sensitivity_value) / JOYSTICK_MAX))))
+
+
 class SensitivityPrefsCameraJoystickAdapter(CameraJoystickAdapter):
+    def __init__(self, js=None, interpolation_function=_linear_interp):
+        CameraJoystickAdapter.__init__(self, js=js)
+        self._interp = interpolation_function
+
     def update_preferences(self):
         CameraJoystickAdapter.update_preferences(self)
         self._set_speed_params()
@@ -220,13 +232,6 @@ class SensitivityPrefsCameraJoystickAdapter(CameraJoystickAdapter):
         self.pan_sensitivity = Preferences.get('joystick.sensitivity.pan', 0.5)
         self.tilt_sensitivity = Preferences.get('joystick.sensitivity.tilt', 0.5)
         self.zoom_sensitivity = Preferences.get('joystick.sensitivity.zoom', 0.5)
-
-    def _interp(self, raw, max_value, sensitivity):
-        sensitivity_value = math.ceil(max_value * sensitivity)
-        if raw <= JOYSTICK_HALF:
-            return max(1, int(math.ceil(sensitivity_value * raw / JOYSTICK_HALF)))
-        else:
-            return max(1, int(sensitivity_value + math.ceil((2 * (raw - JOYSTICK_HALF) * (max_value - sensitivity_value) / JOYSTICK_MAX))))
 
     def map_pan(self, axis):
         return self._interp(abs(axis), self.max_pan, self.pan_sensitivity)

--- a/src/staldates/joystick.py
+++ b/src/staldates/joystick.py
@@ -197,6 +197,15 @@ JOYSTICK_HALF = JOYSTICK_MAX / 2
 
 
 def _linear_interp(raw, max_value, sensitivity):
+    """Linearly interpolates values based on a given percentage sensitivity value.
+
+    The sensitivity represents the percentage of max_value this function should return at 50% input (which is assumed to be a short e.g.
+    the max value from a joystick axis will be 32767).
+
+    Output value is determined by linear interpolation based on that point and the min/max possible output values.
+
+    Setting sensitivity = 0.5 will result in a fully linear response across the entire joystick axis range.
+    """
     sensitivity_value = math.ceil(max_value * sensitivity)
     if raw <= JOYSTICK_HALF:
         return max(1, int(math.ceil(sensitivity_value * raw / JOYSTICK_HALF)))

--- a/src/staldates/joystick.py
+++ b/src/staldates/joystick.py
@@ -110,13 +110,13 @@ PREFS_INVERT_Y = 'joystick.invert_y'
 
 
 class CameraJoystickAdapter(Thread):
-    def __init__(self, js):
+    def __init__(self, js=None):
         super(CameraJoystickAdapter, self).__init__()
         self.daemon = True
         if js:
             js.add_axis_handler(self._handle_axis)
         self._axes = [0, 0, 0, 0]
-        self.set_camera(None)
+        self.set_camera(js)
         self.set_on_move(None)
         self.update_preferences()
         Preferences.subscribe(self.update_preferences)
@@ -207,10 +207,10 @@ class SensitivityPrefsCameraJoystickAdapter(CameraJoystickAdapter):
 
     def _set_speed_params(self):
         if self._camera:
-            self.max_pan = self.camera.maxPanSpeed
-            self.max_tilt = self.camera.maxTiltSpeed
-            self.min_zoom = self.camera.minZoomSpeed
-            self.max_zoom = self.camera.maxZoomSpeed
+            self.max_pan = self._camera.maxPanSpeed
+            self.max_tilt = self._camera.maxTiltSpeed
+            self.min_zoom = self._camera.minZoomSpeed
+            self.max_zoom = self._camera.maxZoomSpeed
         else:
             self.max_pan = 0x18
             self.max_tilt = 0x14

--- a/src/staldates/joystick.py
+++ b/src/staldates/joystick.py
@@ -73,21 +73,21 @@ class Direction(Enum):
         if x > deadzone:
             if y > deadzone:
                 return Direction.UP_RIGHT
-            elif y < -1 * deadzone:
+            elif y < -deadzone:
                 return Direction.DOWN_RIGHT
             else:
                 return Direction.RIGHT
-        elif x < -1 * deadzone:
+        elif x < -deadzone:
             if y > deadzone:
                 return Direction.UP_LEFT
-            elif y < -1 * deadzone:
+            elif y < -deadzone:
                 return Direction.DOWN_LEFT
             else:
                 return Direction.LEFT
         else:
             if y > deadzone:
                 return Direction.UP
-            elif y < -1 * deadzone:
+            elif y < -deadzone:
                 return Direction.DOWN
             else:
                 return Direction.STOP
@@ -102,7 +102,7 @@ class Zoom(Enum):
     def from_axis(axis, deadzone=0):
         if axis > deadzone:
             return Zoom.IN
-        elif axis < -1 * deadzone:
+        elif axis < -deadzone:
             return Zoom.OUT
         return Zoom.STOP
 

--- a/src/staldates/preferences.py
+++ b/src/staldates/preferences.py
@@ -9,7 +9,7 @@ _PREFS_FILE = os.path.join(_PREFS_DIR, 'preferences.json')
 
 
 class _PrefsInstance(QObject):
-    changed = Signal()
+    _changed = Signal(str, object)
 
     def __init__(self):
         QObject.__init__(self)
@@ -41,9 +41,10 @@ class _PrefsInstance(QObject):
     def __setattr__(self, name, value):
         if name[0] == '_':
             return super(_PrefsInstance, self).__setattr__(name, value)
-        self._prefs[name] = value
-        self._save()
-        self.changed.emit()
+        if name not in self._prefs or self._prefs[name] != value:
+            self._prefs[name] = value
+            self._save()
+            self._changed.emit(name, value)
 
 
 class _PreferencesType(type):
@@ -69,3 +70,7 @@ class Preferences:
             return getattr(self, name)
         except (AttributeError, KeyError):
             return default
+
+    @classmethod
+    def subscribe(self, callback):
+        self._changed.connect(callback)

--- a/src/staldates/preferences.py
+++ b/src/staldates/preferences.py
@@ -1,0 +1,64 @@
+from PySide.QtCore import QObject, Signal
+
+import os
+import simplejson
+
+
+_PREFS_DIR = os.path.expanduser('~/.config/av-control')
+_PREFS_FILE = os.path.join(_PREFS_DIR, 'preferences.json')
+
+
+class _PrefsInstance(QObject):
+    changed = Signal()
+
+    def __init__(self):
+        QObject.__init__(self)
+        self._prefs = {}
+        self._load()
+
+    def _load(self):
+        try:
+            with open(_PREFS_FILE, 'r') as prefs_file:
+                self._prefs = simplejson.load(prefs_file)
+        except Exception:
+            print 'No prefs file found or prefs file unreadable'
+
+    def _save(self):
+        try:
+            if not os.path.exists(_PREFS_DIR):
+                os.makedirs(_PREFS_DIR)
+            with open(_PREFS_FILE, 'w') as prefs_file:
+                simplejson.dump(self._prefs, prefs_file)
+        except Exception:
+            print 'Exception while trying to save preferences file'
+            raise
+
+    def __getattr__(self, name):
+        if name[0] == '_':
+            return super(_PrefsInstance, self).__getattr__(name)
+        return self._prefs[name]
+
+    def __setattr__(self, name, value):
+        if name[0] == '_':
+            return super(_PrefsInstance, self).__setattr__(name, value)
+        self._prefs[name] = value
+        self._save()
+        self.changed.emit()
+
+
+class _PreferencesType(type):
+    _instance = _PrefsInstance()
+
+    def __getattr__(self, name):
+        return getattr(self._instance, name)
+
+    def __setattr__(self, name, value):
+        return setattr(self._instance, name, value)
+
+
+class Preferences:
+    """Preferences are accessed statically e.g. `Preferences.my_setting`. Don't instantiate the class."""
+    __metaclass__ = _PreferencesType
+
+    def __init__(self):
+        raise Exception("Preferences should not be instantiated")

--- a/src/staldates/preferences.py
+++ b/src/staldates/preferences.py
@@ -62,3 +62,10 @@ class Preferences:
 
     def __init__(self):
         raise Exception("Preferences should not be instantiated")
+
+    @classmethod
+    def get(self, name, default=None):
+        try:
+            return getattr(self, name)
+        except (AttributeError, KeyError):
+            return default

--- a/src/staldates/preferences.py
+++ b/src/staldates/preferences.py
@@ -34,13 +34,43 @@ class _PrefsInstance(QObject):
             raise
 
     def get(self, name, default=None):
-        return self._prefs.get(name, default)
+        dotpath = name.split('.')
+        return self._get_dotpath(self._prefs, dotpath, default)
 
     def set(self, name, value):
-        if name not in self._prefs or self._prefs[name] != value:
-            self._prefs[name] = value
-            self._save()
+        dotpath = name.split('.')
+        if self._set_dotpath(self._prefs, dotpath, value):
             self._changed.emit(name, value)
+
+    def _get_dotpath(self, container, path, default):
+        if len(path) == 1:
+            return container.get(path[0], default)
+        else:
+            next_container = path.pop(0)
+            if next_container in container:
+                return self._get_dotpath(
+                    container[next_container],
+                    path,
+                    default
+                )
+            else:
+                return default
+
+    def _set_dotpath(self, container, path, value):
+        if len(path) == 1:
+            # We have reached the leaf
+            if path[0] not in container or container[path[0]] != value:
+                container[path[0]] = value
+                self._save()
+                return True
+        else:
+            next_container = path.pop(0)
+            return self._set_dotpath(
+                container.setdefault(next_container, {}),
+                path,
+                value
+            )
+        return False
 
 
 class Preferences(object):

--- a/src/staldates/preferences.py
+++ b/src/staldates/preferences.py
@@ -33,44 +33,31 @@ class _PrefsInstance(QObject):
             print 'Exception while trying to save preferences file'
             raise
 
-    def __getattr__(self, name):
-        if name[0] == '_':
-            return super(_PrefsInstance, self).__getattr__(name)
-        return self._prefs[name]
+    def get(self, name, default=None):
+        return self._prefs.get(name, default)
 
-    def __setattr__(self, name, value):
-        if name[0] == '_':
-            return super(_PrefsInstance, self).__setattr__(name, value)
+    def set(self, name, value):
         if name not in self._prefs or self._prefs[name] != value:
             self._prefs[name] = value
             self._save()
             self._changed.emit(name, value)
 
 
-class _PreferencesType(type):
-    _instance = _PrefsInstance()
-
-    def __getattr__(self, name):
-        return getattr(self._instance, name)
-
-    def __setattr__(self, name, value):
-        return setattr(self._instance, name, value)
-
-
-class Preferences:
+class Preferences(object):
     """Preferences are accessed statically e.g. `Preferences.my_setting`. Don't instantiate the class."""
-    __metaclass__ = _PreferencesType
+    _instance = _PrefsInstance()
 
     def __init__(self):
         raise Exception("Preferences should not be instantiated")
 
     @classmethod
-    def get(self, name, default=None):
-        try:
-            return getattr(self, name)
-        except (AttributeError, KeyError):
-            return default
+    def get(cls, name, default=None):
+        return cls._instance.get(name, default)
 
     @classmethod
-    def subscribe(self, callback):
-        self._changed.connect(callback)
+    def set(cls, name, value):
+        return cls._instance.set(name, value)
+
+    @classmethod
+    def subscribe(cls, callback):
+        cls._instance._changed.connect(callback)

--- a/src/staldates/tests/TestJoystick.py
+++ b/src/staldates/tests/TestJoystick.py
@@ -1,8 +1,8 @@
-from staldates.joystick import Joystick, Direction, Zoom, CameraJoystickAdapter, SensitivityPrefsCameraJoystickAdapter
+from mock import MagicMock, patch, call
+from staldates.joystick import Joystick, Direction, Zoom, CameraJoystickAdapter, SensitivityPrefsCameraJoystickAdapter, _linear_interp
 
 import unittest
 import struct
-from mock import MagicMock, patch, call
 
 
 EVENT_FORMAT = "IhBB"
@@ -172,20 +172,19 @@ class TestSensivityPrefsCJA(unittest.TestCase):
         self.assertEqual(0.8, cja.zoom_sensitivity)
 
     def testInterpolation(self):
-        cja = SensitivityPrefsCameraJoystickAdapter()
         JOY_MAX = 32767
 
         self.assertEqual(
             50,
-            cja._interp((JOY_MAX / 2) - 1, 100, 0.5)
+            _linear_interp((JOY_MAX / 2) - 1, 100, 0.5)
         )
 
         self.assertEqual(
             75,
-            cja._interp(JOY_MAX * 0.74, 100, 0.5)  # Just under - as things get rounded up
+            _linear_interp(JOY_MAX * 0.74, 100, 0.5)  # Just under - as things get rounded up
         )
 
         self.assertEqual(
             75,
-            cja._interp((JOY_MAX / 2) - 1, 100, 0.75)
+            _linear_interp((JOY_MAX / 2) - 1, 100, 0.75)
         )

--- a/src/staldates/ui/resources/AldatesX.qss
+++ b/src/staldates/ui/resources/AldatesX.qss
@@ -122,3 +122,7 @@ QComboBox::drop-down {
 FrameRateTouchSpinner > QLabel {
   font-size: 24pt;
 }
+
+TitleLabel {
+  font-weight: bold;
+}

--- a/src/staldates/ui/widgets/AdvancedMenu.py
+++ b/src/staldates/ui/widgets/AdvancedMenu.py
@@ -2,11 +2,10 @@ from avx._version import __version__ as _avx_version
 from PySide.QtGui import QVBoxLayout, QLabel, QHBoxLayout
 from staldates.ui.widgets.LogViewer import LogViewer
 from staldates.ui.widgets.Buttons import ExpandingButton
+from staldates.ui.widgets.Preferences import PreferencesWidget
 from staldates.ui.widgets.Screens import ScreenWithBackButton
 from staldates.ui._version import __version__ as _ui_version
-from staldates.ui.widgets.TouchSpinner import FrameRateTouchSpinner
 from staldates.VisualsSystem import with_atem
-from PySide.QtCore import Qt
 
 
 class AdvancedMenu(ScreenWithBackButton):
@@ -22,38 +21,30 @@ class AdvancedMenu(ScreenWithBackButton):
         super(AdvancedMenu, self).__init__("Advanced Options", mainWindow)
 
     def makeContent(self):
-        layout = QVBoxLayout()
+        layout = QHBoxLayout()
+
+        prefs = PreferencesWidget(self.controller, self.transition)
+        layout.addWidget(prefs, 1)
+
+        rhs = QVBoxLayout()
 
         lblVersion = QLabel()
         lblVersion.setText("av-control version {0} (avx version {1})".format(_ui_version, _avx_version))
-        layout.addWidget(lblVersion)
-
-        mixCtl = QHBoxLayout()
-        lblMixRate = QLabel("Mix rate:")
-        lblMixRate.setAlignment(Qt.AlignHCenter | Qt.AlignRight)
-        mixCtl.addWidget(lblMixRate, 1)
-
-        mixRate = FrameRateTouchSpinner()
-        mixRate.setValue(self.transition.rate)
-        mixRate.setMaximum(250)
-        mixRate.setMinimum(1)
-        mixRate.valueChanged.connect(self.setMixRate)
-
-        mixCtl.addWidget(mixRate, 1)
-
-        layout.addLayout(mixCtl)
+        rhs.addWidget(lblVersion)
 
         self.lv = LogViewer(self.controller, self.mainWindow)
 
         log = ExpandingButton()
         log.setText("Log")
         log.clicked.connect(self.showLog)
-        layout.addWidget(log)
+        rhs.addWidget(log)
 
         btnQuit = ExpandingButton()
         btnQuit.setText("Exit AV Control")
         btnQuit.clicked.connect(self.mainWindow.close)
-        layout.addWidget(btnQuit)
+        rhs.addWidget(btnQuit)
+
+        layout.addLayout(rhs, 1)
 
         return layout
 

--- a/src/staldates/ui/widgets/Preferences.py
+++ b/src/staldates/ui/widgets/Preferences.py
@@ -1,7 +1,45 @@
-from PySide.QtGui import QWidget, QFormLayout, QVBoxLayout
+from PySide.QtGui import QWidget, QVBoxLayout, QHBoxLayout,\
+    QButtonGroup, QLabel
+from staldates.preferences import Preferences
 from staldates.ui.widgets.Labels import TitleLabel
 from staldates.ui.widgets.TouchSpinner import FrameRateTouchSpinner
 from staldates.VisualsSystem import with_atem
+from staldates.ui.widgets.Buttons import ExpandingButton
+
+
+class JoystickInvertPreference(QWidget):
+    def __init__(self, parent=None):
+        super(JoystickInvertPreference, self).__init__(parent)
+
+        layout = QHBoxLayout()
+        self._btnGroup = QButtonGroup()
+
+        self.btnNormal = ExpandingButton()
+        self.btnNormal.setText('Down')
+        self.btnNormal.setCheckable(True)
+        self.btnNormal.clicked.connect(self.set_preference)
+        self._btnGroup.addButton(self.btnNormal)
+        layout.addWidget(self.btnNormal)
+
+        self.btnInvert = ExpandingButton()
+        self.btnInvert.setText('Up')
+        self.btnInvert.setCheckable(True)
+        self.btnInvert.clicked.connect(self.set_preference)
+        self._btnGroup.addButton(self.btnInvert)
+        layout.addWidget(self.btnInvert)
+
+        self.setLayout(layout)
+
+        self.update_from_preferences()
+        Preferences.subscribe(self.update_from_preferences)
+
+    def update_from_preferences(self):
+        invert_y = Preferences.get('joystick_invert_y', False)
+        self.btnInvert.setChecked(invert_y)
+        self.btnNormal.setChecked(not invert_y)
+
+    def set_preference(self):
+        Preferences.joystick_invert_y = self.btnInvert.isChecked()
 
 
 class PreferencesWidget(QWidget):
@@ -15,17 +53,18 @@ class PreferencesWidget(QWidget):
 
         layout.addWidget(TitleLabel('Preferences'))
 
-        prefsLayout = QFormLayout()
-
         mixRate = FrameRateTouchSpinner()
         mixRate.setValue(transition.rate)
         mixRate.setMaximum(250)
         mixRate.setMinimum(1)
         mixRate.valueChanged.connect(self.setMixRate)
 
-        prefsLayout.addRow('Mix rate:', mixRate)
+        layout.addWidget(QLabel('Mix rate (seconds:frames):'))
+        layout.addWidget(mixRate)
 
-        layout.addLayout(prefsLayout)
+        layout.addWidget(QLabel('Joystick forward means:'))
+        layout.addWidget(JoystickInvertPreference())
+
         self.setLayout(layout)
 
     @with_atem

--- a/src/staldates/ui/widgets/Preferences.py
+++ b/src/staldates/ui/widgets/Preferences.py
@@ -1,0 +1,33 @@
+from PySide.QtGui import QWidget, QFormLayout, QVBoxLayout
+from staldates.ui.widgets.Labels import TitleLabel
+from staldates.ui.widgets.TouchSpinner import FrameRateTouchSpinner
+from staldates.VisualsSystem import with_atem
+
+
+class PreferencesWidget(QWidget):
+    def __init__(self, controller, transition, parent=None):
+        super(PreferencesWidget, self).__init__(parent)
+        self.controller = controller
+        self.transition = transition
+        self.atem = controller['ATEM']
+
+        layout = QVBoxLayout()
+
+        layout.addWidget(TitleLabel('Preferences'))
+
+        prefsLayout = QFormLayout()
+
+        mixRate = FrameRateTouchSpinner()
+        mixRate.setValue(transition.rate)
+        mixRate.setMaximum(250)
+        mixRate.setMinimum(1)
+        mixRate.valueChanged.connect(self.setMixRate)
+
+        prefsLayout.addRow('Mix rate:', mixRate)
+
+        layout.addLayout(prefsLayout)
+        self.setLayout(layout)
+
+    @with_atem
+    def setMixRate(self, rate):
+        self.atem.setMixTransitionRate(rate)

--- a/src/staldates/ui/widgets/Preferences.py
+++ b/src/staldates/ui/widgets/Preferences.py
@@ -1,8 +1,10 @@
+from PySide.QtCore import Qt
 from PySide.QtGui import QWidget, QVBoxLayout, QHBoxLayout,\
     QButtonGroup, QLabel
 from staldates.preferences import Preferences
 from staldates.ui.widgets.Labels import TitleLabel
-from staldates.ui.widgets.TouchSpinner import FrameRateTouchSpinner
+from staldates.ui.widgets.TouchSpinner import FrameRateTouchSpinner,\
+    TouchSpinner
 from staldates.VisualsSystem import with_atem
 from staldates.ui.widgets.Buttons import ExpandingButton
 
@@ -42,6 +44,32 @@ class JoystickInvertPreference(QWidget):
         Preferences.set('joystick.invert_y', self.btnInvert.isChecked())
 
 
+class SensitivityPreference(QWidget):
+    def __init__(self, preference_name, label, parent=None):
+        super(SensitivityPreference, self).__init__(parent)
+        self.preference_name = preference_name
+
+        layout = QHBoxLayout()
+
+        label = QLabel(label)
+        label.setAlignment(Qt.AlignRight)
+        layout.addWidget(label, 1)
+
+        self.spinner = TouchSpinner()
+        self.spinner.setMaximum(10)
+        self.spinner.setMinimum(1)
+
+        self.update_from_preferences()
+        Preferences.subscribe(self.update_from_preferences)
+        self.spinner.valueChanged.connect(lambda v: Preferences.set(preference_name, float(v) / 10))
+        layout.addWidget(self.spinner, 2)
+
+        self.setLayout(layout)
+
+    def update_from_preferences(self):
+        self.spinner.setValue(int(Preferences.get(self.preference_name, 0.5) * 10))
+
+
 class PreferencesWidget(QWidget):
     def __init__(self, controller, transition, parent=None):
         super(PreferencesWidget, self).__init__(parent)
@@ -64,6 +92,11 @@ class PreferencesWidget(QWidget):
 
         layout.addWidget(QLabel('Joystick forward means:'))
         layout.addWidget(JoystickInvertPreference())
+
+        layout.addWidget(QLabel('Joystick sensitivity:'))
+        layout.addWidget(SensitivityPreference('joystick.sensitivity.pan', 'Pan'))
+        layout.addWidget(SensitivityPreference('joystick.sensitivity.tilt', 'Tilt'))
+        layout.addWidget(SensitivityPreference('joystick.sensitivity.zoom', 'Zoom'))
 
         self.setLayout(layout)
 

--- a/src/staldates/ui/widgets/Preferences.py
+++ b/src/staldates/ui/widgets/Preferences.py
@@ -34,12 +34,12 @@ class JoystickInvertPreference(QWidget):
         Preferences.subscribe(self.update_from_preferences)
 
     def update_from_preferences(self):
-        invert_y = Preferences.get('joystick_invert_y', False)
+        invert_y = Preferences.get('joystick.invert_y', False)
         self.btnInvert.setChecked(invert_y)
         self.btnNormal.setChecked(not invert_y)
 
     def set_preference(self):
-        Preferences.set('joystick_invert_y', self.btnInvert.isChecked())
+        Preferences.set('joystick.invert_y', self.btnInvert.isChecked())
 
 
 class PreferencesWidget(QWidget):

--- a/src/staldates/ui/widgets/Preferences.py
+++ b/src/staldates/ui/widgets/Preferences.py
@@ -39,7 +39,7 @@ class JoystickInvertPreference(QWidget):
         self.btnNormal.setChecked(not invert_y)
 
     def set_preference(self):
-        Preferences.joystick_invert_y = self.btnInvert.isChecked()
+        Preferences.set('joystick_invert_y', self.btnInvert.isChecked())
 
 
 class PreferencesWidget(QWidget):

--- a/src/staldates/ui/widgets/TouchSpinner.py
+++ b/src/staldates/ui/widgets/TouchSpinner.py
@@ -14,21 +14,21 @@ class TouchSpinner(QWidget):
 
         layout = QHBoxLayout()
 
-        btnMinus = ExpandingButton()
-        btnMinus.setIcon(QIcon(":icons/list-remove"))
-        btnMinus.setText("-")
-        btnMinus.clicked.connect(lambda: self.setValue(self._value - 1))
-        layout.addWidget(btnMinus, 1)
+        self.btnMinus = ExpandingButton()
+        self.btnMinus.setIcon(QIcon(":icons/list-remove"))
+        self.btnMinus.setText("-")
+        self.btnMinus.clicked.connect(lambda: self.setValue(self._value - 1))
+        layout.addWidget(self.btnMinus, 1)
 
         self.lblValue = QLabel(self.formattedValue(self._value))
         self.lblValue.setAlignment(Qt.AlignHCenter)
         layout.addWidget(self.lblValue, 1)
 
-        btnPlus = ExpandingButton()
-        btnPlus.setIcon(QIcon(":icons/list-add"))
-        btnPlus.setText("+")
-        btnPlus.clicked.connect(lambda: self.setValue(self._value + 1))
-        layout.addWidget(btnPlus, 1)
+        self.btnPlus = ExpandingButton()
+        self.btnPlus.setIcon(QIcon(":icons/list-add"))
+        self.btnPlus.setText("+")
+        self.btnPlus.clicked.connect(lambda: self.setValue(self._value + 1))
+        layout.addWidget(self.btnPlus, 1)
 
         self.setLayout(layout)
 
@@ -43,6 +43,9 @@ class TouchSpinner(QWidget):
             self._value = newValue
             self.valueChanged.emit(newValue)
             self.lblValue.setText(self.formattedValue(newValue))
+
+            self.btnPlus.setEnabled(self._value < self._max)
+            self.btnMinus.setEnabled(self._value > self._min)
 
     def setMaximum(self, maxi):
         self._max = maxi

--- a/src/staldates/ui/widgets/tests/TestTouchSpinner.py
+++ b/src/staldates/ui/widgets/tests/TestTouchSpinner.py
@@ -1,0 +1,45 @@
+from mock import MagicMock, call
+from staldates.ui.tests.GuiTest import GuiTest
+from staldates.ui.widgets.TouchSpinner import TouchSpinner
+
+
+class TestTouchSpinner(GuiTest):
+    def testValueChange(self):
+        ts = TouchSpinner()
+        signal_receiver = MagicMock()
+        ts.valueChanged.connect(signal_receiver)
+
+        self.assertEqual(50, ts.value())
+        self.findButton(ts, '+').click()
+        self.assertEqual(51, ts.value())
+        self.findButton(ts, '-').click()
+        self.assertEqual(50, ts.value())
+
+        signal_receiver.assert_has_calls([
+            call(51),
+            call(50)
+        ])
+
+        ts.valueChanged.disconnect(signal_receiver)
+
+    def testMinMax(self):
+        ts = TouchSpinner()
+        ts.setMinimum(49)
+        ts.setMaximum(51)
+
+        plus = self.findButton(ts, '+')
+        minus = self.findButton(ts, '-')
+
+        self.assertEqual(50, ts.value())
+        plus.click()
+        self.assertEqual(51, ts.value())
+        self.assertFalse(plus.isEnabled())
+        minus.click()
+        minus.click()
+        self.assertTrue(plus.isEnabled())
+        self.assertFalse(minus.isEnabled())
+
+        ts.setValue(52)
+        self.assertEqual(51, ts.value())
+        ts.setValue(42)
+        self.assertEqual(49, ts.value())


### PR DESCRIPTION
This PR adds persistent preferences for joystick operation, namely:
 - Invertion of y-axis (#26)
 - Adjustment of sensitivity, per-axis

Sensitivity adjustment is achieved by defining a VISCA speed value for a point halfway along the joystick axis. Other values are then linearly interpolated in the ranges from zero to this point, or from this point to the maximum values.

The sensitivity is expressed as a percentage, where 0.5 will give a completely linear response. In the UI this is displayed as an integer between 1 and 10 inclusive.

These preferences are set on the "Advanced" screen.