### PR TITLE
Reduce potential conflicts of multiple users moving a camera

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,13 @@ setup(
     author='James Muscat',
     author_email='jamesremuscat@gmail.com',
     url='https://github.com/staldates/av-control',
-    install_requires=['avx>=1.3.0.dev0', "Pyro4>=4.20,!=4.45", 'PySide', 'simplejson'],
+    install_requires=[
+        'avx>=1.3.0.dev0',
+        'enum34',
+        "Pyro4>=4.20,!=4.45",
+        'PySide',
+        'simplejson'
+    ],
     setup_requires=['nose>=1.0'],
     tests_require = ['mock'],
     packages=find_packages('src', exclude=["*.tests"]),

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,8 @@ setup(
         'enum34',
         "Pyro4>=4.20,!=4.45",
         'PySide',
-        'simplejson'
+        'simplejson',
+        'uuid'
     ],
     setup_requires=['nose>=1.0'],
     tests_require = ['mock'],

--- a/src/staldates/VisualsSystem.py
+++ b/src/staldates/VisualsSystem.py
@@ -299,6 +299,7 @@ class Camera(QObject):
         self._attr_cache = {}
         self._uuid = uuid4()
         self.is_controlled = False
+        self._timer = None
 
     def __getattr__(self, name):
         proxied_attr = getattr(self._camera, name)
@@ -321,7 +322,12 @@ class Camera(QObject):
     def control(self):
         self.is_controlled = True
         self.controlled.emit()
-        QTimer.singleShot(5000, self.uncontrol)
+        if self._timer:
+            self._timer.stop()
+        self._timer = QTimer()
+        self._timer.setSingleShot(True)
+        self._timer.timeout.connect(self.uncontrol)
+        self._timer.start(5000)
 
     def uncontrol(self):
         self.is_controlled = False

--- a/src/staldates/VisualsSystem.py
+++ b/src/staldates/VisualsSystem.py
@@ -292,6 +292,8 @@ class Camera(QObject):
     controlled = Signal()
     uncontrolled = Signal()
 
+    CONTROL_TIMEOUT = 2500
+
     def __init__(self, camera_id, camera_device):
         super(Camera, self).__init__()
         self._camera = camera_device
@@ -327,7 +329,7 @@ class Camera(QObject):
         self._timer = QTimer()
         self._timer.setSingleShot(True)
         self._timer.timeout.connect(self.uncontrol)
-        self._timer.start(5000)
+        self._timer.start(self.CONTROL_TIMEOUT)
 
     def uncontrol(self):
         self.is_controlled = False

--- a/src/staldates/__init__.py
+++ b/src/staldates/__init__.py
@@ -2,3 +2,4 @@ class MessageTypes(object):
     SHOW_POWER_ON = "staldates.avcontrol.showPowerOn"
     SHOW_POWER_OFF = "staldates.avcontrol.showPowerOff"
     HIDE_POWER = "staldates.avcontrol.hidePower"
+    CAMERA_CONTROLLED = 'staldates.avcontrol.cameraControlled'

--- a/src/staldates/ui/CameraControls.py
+++ b/src/staldates/ui/CameraControls.py
@@ -179,7 +179,7 @@ class CameraControl(QWidget):
         lbl_controlled.setAlignment(Qt.AlignHCenter | Qt.AlignVCenter)
         uncontrollable_layout.addWidget(lbl_controlled)
 
-        btn_uncontrol = QPushButton('Ignore')
+        btn_uncontrol = QPushButton('Dismiss')
         btn_uncontrol.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Minimum)
         btn_uncontrol.clicked.connect(self.camera.uncontrol)
         uncontrollable_layout.addWidget(btn_uncontrol)

--- a/src/staldates/ui/MainWindow.py
+++ b/src/staldates/ui/MainWindow.py
@@ -167,3 +167,5 @@ class MainWindow(QMainWindow):
             self.switcherState.handleMessage(msgType, data)
         elif sourceDeviceID == "Recorder":
             self.hyperdeckState.handleMessage(msgType, data)
+        else:
+            self.mainScreen.handleMessage(msgType, sourceDeviceID, data)

--- a/src/staldates/ui/VideoSwitcher.py
+++ b/src/staldates/ui/VideoSwitcher.py
@@ -7,7 +7,7 @@ from staldates.ui.CameraControls import CameraControl, AdvancedCameraControl
 from staldates.ui.StringConstants import StringConstants
 from staldates.ui.widgets.AllInputsPanel import AllInputsPanel
 from staldates.ui.widgets.OverlayControl import OverlayControl
-from staldates.VisualsSystem import with_atem
+from staldates.VisualsSystem import with_atem, Camera
 from staldates.ui.widgets.FadeToBlackControl import FadeToBlackControl
 
 
@@ -20,6 +20,7 @@ class VideoSwitcher(QWidget):
         self.controller = controller
         self.switcherState = switcherState
         self.joystickAdapter = joystickAdapter
+        self._camera_proxies = {}
         self.setupUi()
 
     def setupUi(self):
@@ -40,12 +41,14 @@ class VideoSwitcher(QWidget):
 
         def makeCamera(videoSource, cameraID):
             cam = self.controller[cameraID]
-            cc = CameraControl(cam)
+            cam_proxy = Camera(cameraID, cam)
+            cc = CameraControl(cam_proxy)
+            self._camera_proxies[cameraID] = cam_proxy
 
             return (
                 videoSource,
                 cc,
-                AdvancedCameraControl(cameraID, cam, self.mainWindow),
+                AdvancedCameraControl(cameraID, cam_proxy, self.mainWindow),
                 lambda: setCamera(cam, cc)
             )
 
@@ -192,3 +195,7 @@ class VideoSwitcher(QWidget):
         panel = self.sender().property("adv_panel")
         if panel:
             self.mainWindow.showScreen(panel)
+
+    def handleMessage(self, msgType, sourceDeviceID, data):
+        for cp in self._camera_proxies.values():
+            cp.handleMessage(msgType, sourceDeviceID, data)

--- a/src/staldates/ui/resources/AldatesX.qss
+++ b/src/staldates/ui/resources/AldatesX.qss
@@ -21,7 +21,7 @@ MainMixControl > QLabel {
   font-size: 12pt;
 }
 
-InputButton, OutputButton, OptionButton, ExpandingButton, QComboBox, QListView {
+InputButton, OutputButton, OptionButton, ExpandingButton, QComboBox, QListView, CameraControl QPushButton {
   background-color: #1693A5;
   color: white;
   border-radius: 5px;
@@ -34,7 +34,7 @@ ExpandingButton.mainMix {
   color: black;
 }
 
-ExpandingButton:pressed, ExpandingButton:checked {
+ExpandingButton:pressed, ExpandingButton:checked, CameraControl QPushButton:pressed {
   background-color: #E4E4FF;
   color: black;
 }


### PR DESCRIPTION
This PR introduces a mechanism whereby one user moving a camera broadcasts a message via the avx controller to prevent other users also trying to move the camera.

When such a message is received by another `av-control` client, it replaces the camera controls with the following:
![av-control_032](https://user-images.githubusercontent.com/3471844/91494808-5b7d1180-e8b1-11ea-9b2f-030b3497fe9f.png)

The message can be dismissed with the button, but will disappear 2.5 seconds after the most recent message is received (multiple messages will extend the period for which this message is shown). I'm not quite sure if that's a suitable amount of time or not - it's less than the 5 seconds I first envisaged but more than the 1-2 that @rjmunro suggested. We might need to tweak this once we start using it.

Resolves #38.
