### PR TITLE
Access more camera presets

### DIFF
--- a/src/staldates/ui/CameraControls.py
+++ b/src/staldates/ui/CameraControls.py
@@ -163,6 +163,8 @@ class CameraControl(QWidget):
             presets.addWidget(btnPresetSet, 1, i, 1, 1)
             btnPresetSet.setText("Set")
             _safelyConnect(btnPresetSet.clicked, lambda i=i: self.storePreset(i))
+
+        Preferences.subscribe(self._update_from_preferences)
         self._update_from_preferences()
 
         layout.addLayout(presets, 4, 0, 3, 6)

--- a/src/staldates/ui/CameraControls.py
+++ b/src/staldates/ui/CameraControls.py
@@ -198,7 +198,6 @@ class CameraControl(QWidget):
     def storePreset(self, index):
         preset_bank = Preferences.get('camera.presets.bank', 0)
         preset_index = (6 * preset_bank) + index
-        print "Storing preset " + str(preset_index)
         result = self.camera.storePreset(preset_index)
         self.presetGroup.buttons()[index - 1].setChecked(True)
         return result
@@ -206,11 +205,7 @@ class CameraControl(QWidget):
     @handlePyroErrors
     def recallPreset(self, index):
         preset_bank = Preferences.get('camera.presets.bank', 0)
-        print('Preset bank: {}'.format(preset_bank))
         preset_index = (6 * preset_bank) + index
-        print "Recalling preset {} = {}".format(
-            index, preset_index
-        )
         return self.camera.recallPreset(preset_index)
 
     def deselectPreset(self):

--- a/src/staldates/ui/MainWindow.py
+++ b/src/staldates/ui/MainWindow.py
@@ -103,7 +103,7 @@ class MainWindow(QMainWindow):
         self.advMenu = AdvancedMenu(self.controller, self.switcherState.mixTransition, atem, self)
 
         adv = ExpandingButton()
-        adv.setText("Advanced")
+        adv.setText("Preferences")
         adv.setIcon(QIcon(":icons/applications-system"))
         adv.setToolButtonStyle(Qt.ToolButtonStyle.ToolButtonTextBesideIcon)
         adv.clicked.connect(lambda: self.showScreen(self.advMenu))

--- a/src/staldates/ui/widgets/AdvancedMenu.py
+++ b/src/staldates/ui/widgets/AdvancedMenu.py
@@ -18,33 +18,36 @@ class AdvancedMenu(ScreenWithBackButton):
         self.mainWindow = mainWindow
         self.transition = transition
         self.atem = atem
-        super(AdvancedMenu, self).__init__("Advanced Options", mainWindow)
+        super(AdvancedMenu, self).__init__("Preferences", mainWindow)
 
     def makeContent(self):
-        layout = QHBoxLayout()
+        layout = QVBoxLayout()
 
         prefs = PreferencesWidget(self.controller, self.transition)
-        layout.addWidget(prefs, 1)
-
-        rhs = QVBoxLayout()
-
-        lblVersion = QLabel()
-        lblVersion.setText("av-control version {0} (avx version {1})".format(_ui_version, _avx_version))
-        rhs.addWidget(lblVersion)
+        layout.addWidget(prefs)
 
         self.lv = LogViewer(self.controller, self.mainWindow)
+
+        bottom_row = QHBoxLayout()
+
+        lblVersion = QLabel()
+        lblVersion.setText("av-control version {0}\navx version {1}".format(_ui_version, _avx_version))
+        bottom_row.addWidget(lblVersion)
 
         log = ExpandingButton()
         log.setText("Log")
         log.clicked.connect(self.showLog)
-        rhs.addWidget(log)
+        bottom_row.addWidget(log)
 
         btnQuit = ExpandingButton()
         btnQuit.setText("Exit AV Control")
         btnQuit.clicked.connect(self.mainWindow.close)
-        rhs.addWidget(btnQuit)
+        bottom_row.addWidget(btnQuit)
 
-        layout.addLayout(rhs, 1)
+        for i in range(3):
+            bottom_row.setStretch(i, 1)
+
+        layout.addLayout(bottom_row)
 
         return layout
 

--- a/src/staldates/ui/widgets/TouchSpinner.py
+++ b/src/staldates/ui/widgets/TouchSpinner.py
@@ -21,7 +21,7 @@ class TouchSpinner(QWidget):
         layout.addWidget(self.btnMinus, 1)
 
         self.lblValue = QLabel(self.formattedValue(self._value))
-        self.lblValue.setAlignment(Qt.AlignHCenter)
+        self.lblValue.setAlignment(Qt.AlignHCenter | Qt.AlignVCenter)
         layout.addWidget(self.lblValue, 1)
 
         self.btnPlus = ExpandingButton()


### PR DESCRIPTION
This PR adds the ability to access camera presets higher than 6.

The PTC-150s have the ability to store 50 (or possibly 51) presets including position, zoom, focus, brightness, iris, and white balance. Previously we've only used 1–6 of these - the old Sony EVI-D30s only had six available.

In order to unlock (most of) the remaining presets, they have been divided into "banks" of six, and a preference has been added for which "bank" to display on the camera controls:
![av-control_034](https://user-images.githubusercontent.com/3471844/91643692-6a88ce80-ea2d-11ea-86ce-20672a3b35d8.png)

I've shuffled things around on the preferences screen to fit things better:
![av-control_033](https://user-images.githubusercontent.com/3471844/91643690-65c41a80-ea2d-11ea-91f6-4a55f32d4630.png)

There are eight banks of six presets available (== 48 of the 51), numbered from `0` to `7`.

Resolves #21.