### PR TITLE
Support controlling separate M/E buses

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+avx-venv
+venv
+build
+dist

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM ubuntu:18.04
+
+RUN apt-get update && apt-get install -y pyside-tools && apt-get clean
+
+VOLUME /av-control
+
+CMD cd /av-control && ./compileResources.sh

--- a/setup.py
+++ b/setup.py
@@ -22,9 +22,9 @@ setup(
     url='https://github.com/staldates/av-control',
     install_requires=['avx>1.3.0', "Pyro4>=4.20,!=4.45", 'PySide', 'simplejson'],
     setup_requires=['nose>=1.0'],
-    tests_require = ['mock'],
+    tests_require=['mock'],
     packages=find_packages('src', exclude=["*.tests"]),
-    package_dir = {'':'src'},
+    package_dir={'': 'src'},
     entry_points={
         'console_scripts': [
             'av-control = staldates.avcontrol:main'

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
     author='James Muscat',
     author_email='jamesremuscat@gmail.com',
     url='https://github.com/staldates/av-control',
-    install_requires=['avx>=1.3.0.dev0', "Pyro4>=4.20,!=4.45", 'PySide', 'simplejson'],
+    install_requires=['avx>1.3.0', "Pyro4>=4.20,!=4.45", 'PySide', 'simplejson'],
     setup_requires=['nose>=1.0'],
     tests_require = ['mock'],
     packages=find_packages('src', exclude=["*.tests"]),

--- a/src/staldates/VisualsSystem.py
+++ b/src/staldates/VisualsSystem.py
@@ -61,7 +61,7 @@ def _default_inputs():
         (VideoSource.INPUT_5, "Visuals PC", QIcon(":icons/computer")),
         (VideoSource.INPUT_6, "PC Video", QIcon(":icons/video-display")),
         (VideoSource.BLACK, "Black", QIcon(":icons/blackscreen")),
-        (VideoSource.ME_1_PROGRAM, "Stream mix", None),
+        (VideoSource.ME_1_PROGRAM, "Stream mix", QIcon(':icons/stream')),
         (VideoSource.ME_1_PREVIEW, "Stream preview", None),
         (VideoSource.ME_2_PROGRAM, "Main mix", None),
         (VideoSource.ME_2_PREVIEW, "Preview", None),

--- a/src/staldates/VisualsSystem.py
+++ b/src/staldates/VisualsSystem.py
@@ -48,7 +48,7 @@ class Input(QObject):
     def set_tally(self, tally):
         for me, sources in tally.iteritems():
             self.tally.setdefault(me, {})['pgm'] = self.source in sources['pgm']
-            self.tally.setdefault(me, {})['pvw'] = self.source in sources['pvw']
+            self.tally.setdefault(me, {})['pvw'] = self.source in sources['prv']
         self.changedState.emit()
 
 

--- a/src/staldates/VisualsSystem.py
+++ b/src/staldates/VisualsSystem.py
@@ -240,6 +240,10 @@ class SwitcherState(QObject):
         if 'rate' in props:
             self.mixTransition.set_rate(props['rate'])
 
+    @property
+    def me_index(self):
+        return self.me - 1
+
     def handleMessage(self, msgType, data):
         if msgType == ATEMMessageTypes.TALLY:
             self.updateTally(data)
@@ -250,14 +254,14 @@ class SwitcherState(QObject):
         elif msgType == ATEMMessageTypes.INPUTS_CHANGED:
             self.updateInputs(self.atem.getInputs())
         elif msgType == ATEMMessageTypes.FTB_CHANGED:
-            if 0 in data:
-                self.updateFTBState(data[0])
+            if self.me_index in data:
+                self.updateFTBState(data[self.me_index])
         elif msgType == ATEMMessageTypes.FTB_RATE_CHANGED:
-            if 0 in data:
-                self.updateFTBRate(data[0])
+            if self.me_index in data:
+                self.updateFTBRate(data[self.me_index])
         elif msgType == ATEMMessageTypes.TRANSITION_MIX_PROPERTIES_CHANGED:
-            if 0 in data:
-                self.updateMixTransitionProps(data[0])
+            if self.me_index in data:
+                self.updateMixTransitionProps(data[self.me_index])
         elif msgType == ATEMMessageTypes.ATEM_CONNECTED:
             self._initFromAtem()
         elif msgType == ATEMMessageTypes.ATEM_DISCONNECTED:

--- a/src/staldates/VisualsSystem.py
+++ b/src/staldates/VisualsSystem.py
@@ -54,7 +54,10 @@ def _default_inputs():
         (VideoSource.INPUT_5, "Visuals PC", QIcon(":icons/computer")),
         (VideoSource.INPUT_6, "PC Video", QIcon(":icons/video-display")),
         (VideoSource.BLACK, "Black", QIcon(":icons/blackscreen")),
-        (VideoSource.ME_1_PROGRAM, "Main mix", None),
+        (VideoSource.ME_1_PROGRAM, "Stream mix", None),
+        (VideoSource.ME_1_PREVIEW, "Stream preview", None),
+        (VideoSource.ME_2_PROGRAM, "Main mix", None),
+        (VideoSource.ME_2_PREVIEW, "Preview", None),
     ]}
 
 

--- a/src/staldates/VisualsSystem.py
+++ b/src/staldates/VisualsSystem.py
@@ -192,7 +192,16 @@ class SwitcherState(QObject):
         self.me = me
         self.inputs = _default_inputs()
         self.outputs = _default_outputs()
-        self.usks = {}
+        self.usks = {
+            0: {
+                0: USK(0, 0),
+                1: USK(0, 1),
+            },
+            1: {
+                0: USK(1, 0),
+                1: USK(1, 1),
+            },
+        }
         self.dsks = {0: DSK(1), 1: DSK(2)}
         self.ftb = FadeToBlack()
         self.mixTransition = MixTransition()

--- a/src/staldates/VisualsSystem.py
+++ b/src/staldates/VisualsSystem.py
@@ -161,9 +161,10 @@ class SwitcherState(QObject):
     inputsChanged = Signal()
     connectionChanged = Signal(bool)
 
-    def __init__(self, atem):
+    def __init__(self, atem, me=1):
         super(SwitcherState, self).__init__()
         self.atem = atem
+        self.me = me
         self.inputs = _default_inputs()
         self.outputs = _default_outputs()
         self.dsks = {0: DSK(1), 1: DSK(2)}
@@ -181,9 +182,9 @@ class SwitcherState(QObject):
                 self.updateTally(self.atem.getTally())
                 self.updateOutputs(self.atem.getAuxState())
                 self.updateDSKs(self.atem.getDSKState())
-                self.updateFTBState(self.atem.getFadeToBlackState(me=1))
-                self.updateFTBRate(self.atem.getFadeToBlackProperties(me=1)['rate'])
-                self.updateMixTransitionProps(self.atem.getMixTransitionProps(me=1))
+                self.updateFTBState(self.atem.getFadeToBlackState(me=self.me))
+                self.updateFTBRate(self.atem.getFadeToBlackProperties(me=self.me)['rate'])
+                self.updateMixTransitionProps(self.atem.getMixTransitionProps(me=self.me))
             except NotInitializedException:
                 pass
 

--- a/src/staldates/preferences.py
+++ b/src/staldates/preferences.py
@@ -74,7 +74,10 @@ class _PrefsInstance(QObject):
 
 
 class Preferences(object):
-    """Preferences are accessed statically e.g. `Preferences.my_setting`. Don't instantiate the class."""
+    """
+    Preferences are accessed statically e.g. `Preferences.get(my_setting)`.
+    Don't instantiate the class.
+    """
     _instance = _PrefsInstance()
 
     def __init__(self):

--- a/src/staldates/ui/MainWindow.py
+++ b/src/staldates/ui/MainWindow.py
@@ -13,6 +13,7 @@ from staldates.ui.widgets.LightingControl import LightingControl
 from staldates.ui.widgets.Status import SystemStatus
 from staldates.VisualsSystem import SwitcherState, HyperdeckState
 from staldates import MessageTypes
+from staldates.preferences import Preferences
 from staldates.ui.StringConstants import StringConstants
 from staldates.ui.widgets.RecorderControl import RecorderControl
 from avx.devices.net.hyperdeck import TransportState
@@ -29,9 +30,16 @@ class MainWindow(QMainWindow):
         self.setWindowIcon(QIcon(":icons/video-display"))
 
         atem = controller['ATEM']
-        self.switcherState = SwitcherState(atem)
+        me = Preferences.get('atem_me', 1)
+        self.switcherState = SwitcherState(atem, me)
 
-        self.mainScreen = VideoSwitcher(controller, self, self.switcherState, joystickAdapter)
+        self.mainScreen = VideoSwitcher(
+            controller,
+            self,
+            self.switcherState,
+            me,
+            joystickAdapter
+        )
 
         # This is possibly a bad / too complicated idea...
         # self.mainScreen.setEnabled(self.switcherState.connected)

--- a/src/staldates/ui/VideoSwitcher.py
+++ b/src/staldates/ui/VideoSwitcher.py
@@ -107,7 +107,7 @@ class VideoSwitcher(QWidget):
 
         layout.addLayout(inputs_grid, 0, 0, 1, 7)
 
-        self.og = OutputsGrid(self.switcherState)
+        self.og = OutputsGrid(self.switcherState, self.me)
 
         self.og.take.connect(self.take)
         self.og.cut.connect(self.cut)

--- a/src/staldates/ui/VideoSwitcher.py
+++ b/src/staldates/ui/VideoSwitcher.py
@@ -55,12 +55,18 @@ class VideoSwitcher(QWidget):
                 self.joystickAdapter.set_camera(None)
                 self.joystickAdapter.set_on_move(None)
 
+        overlayControl = OverlayControl(
+            self.switcherState.usks[1][0],
+            self.switcherState.mixTransition,
+            self.atem
+        )
+
         self.input_buttons_config = [
             ifDevice("Camera 1", lambda: makeCamera(VideoSource.INPUT_1, "Camera 1")),
             ifDevice("Camera 2", lambda: makeCamera(VideoSource.INPUT_2, "Camera 2")),
             ifDevice("Camera 3", lambda: makeCamera(VideoSource.INPUT_3, "Camera 3")),
             (VideoSource.INPUT_4, QLabel(StringConstants.noDevice), None, deselectCamera),
-            (VideoSource.INPUT_5, OverlayControl(self.switcherState.dsks[0], self.atem), None, deselectCamera),
+            (VideoSource.INPUT_5, overlayControl, None, deselectCamera),
             (VideoSource.INPUT_6, QLabel(StringConstants.noDevice), None, deselectCamera)
         ]
 

--- a/src/staldates/ui/VideoSwitcher.py
+++ b/src/staldates/ui/VideoSwitcher.py
@@ -56,7 +56,7 @@ class VideoSwitcher(QWidget):
                 self.joystickAdapter.set_on_move(None)
 
         overlayControl = OverlayControl(
-            self.switcherState.usks[1][0],
+            self.switcherState.usks[self.me - 1][0],
             self.switcherState.mixTransition,
             self.atem
         )

--- a/src/staldates/ui/VideoSwitcher.py
+++ b/src/staldates/ui/VideoSwitcher.py
@@ -100,7 +100,7 @@ class VideoSwitcher(QWidget):
         self.blackBtn.clicked.connect(self.preview)
         self.blackBtn.clicked.connect(self.displayPanel)
         self.blackBtn.clicked.connect(deselectCamera)
-        self.ftb = FadeToBlackControl(self.switcherState.ftb, self.atem)
+        self.ftb = FadeToBlackControl(self.switcherState.ftb, self.atem, self.me)
         self.blackBtn.setProperty("panel", self.ftb)
         self.blackBtn.flashing = self.switcherState.ftb.active
         self.switcherState.ftb.activeChanged.connect(self.blackBtn.setFlashing)

--- a/src/staldates/ui/VideoSwitcher.py
+++ b/src/staldates/ui/VideoSwitcher.py
@@ -93,7 +93,7 @@ class VideoSwitcher(QWidget):
         # without actually showing a menu when pressed.
         self.extrasBtn.setMenu(QMenu())
 
-        self.allInputs = AllInputsPanel(self.switcherState)
+        self.allInputs = AllInputsPanel(self.switcherState, self.me)
         self.extrasBtn.setProperty("panel", self.allInputs)
 
         self.allInputs.inputSelected.connect(self.setExtraInput)

--- a/src/staldates/ui/VideoSwitcher.py
+++ b/src/staldates/ui/VideoSwitcher.py
@@ -83,7 +83,7 @@ class VideoSwitcher(QWidget):
                 self.inputs.addButton(btn)
                 inputs_grid.addWidget(btn)
 
-        self.extrasBtn = InputButton(None)
+        self.extrasBtn = InputButton(None, main_me=self.me)
         self.inputs.addButton(self.extrasBtn)
         self.extrasBtn.clicked.connect(self.preview)
         self.extrasBtn.clicked.connect(self.displayPanel)

--- a/src/staldates/ui/VideoSwitcher.py
+++ b/src/staldates/ui/VideoSwitcher.py
@@ -100,7 +100,10 @@ class VideoSwitcher(QWidget):
 
         inputs_grid.addWidget(self.extrasBtn)
 
-        self.blackBtn = FlashingInputButton(self.switcherState.inputs[VideoSource.BLACK])
+        self.blackBtn = FlashingInputButton(
+            self.switcherState.inputs[VideoSource.BLACK],
+            main_me=self.me
+        )
         inputs_grid.addWidget(self.blackBtn)
         self.inputs.addButton(self.blackBtn)
         self.blackBtn.clicked.connect(self.preview)

--- a/src/staldates/ui/VideoSwitcher.py
+++ b/src/staldates/ui/VideoSwitcher.py
@@ -66,7 +66,7 @@ class VideoSwitcher(QWidget):
 
         for source, panel, adv_panel, on_select_func in self.input_buttons_config:
             if source:
-                btn = InputButton(self.switcherState.inputs[source])
+                btn = InputButton(self.switcherState.inputs[source], main_me=self.me)
                 btn.setProperty("panel", panel)
                 btn.setProperty("adv_panel", adv_panel)
                 btn.clicked.connect(self.preview)

--- a/src/staldates/ui/_version.py
+++ b/src/staldates/ui/_version.py
@@ -1,3 +1,3 @@
 # Note: this is not the same as the avx library version!
 # It is the latter that gets checked for compatibility with the controller.
-__version__ = "1.2.0"
+__version__ = "1.3.0-jrem"

--- a/src/staldates/ui/_version.py
+++ b/src/staldates/ui/_version.py
@@ -1,3 +1,3 @@
 # Note: this is not the same as the avx library version!
 # It is the latter that gets checked for compatibility with the controller.
-__version__ = "1.3.0-jrem"
+__version__ = "1.3.0"

--- a/src/staldates/ui/resources.qrc
+++ b/src/staldates/ui/resources.qrc
@@ -15,6 +15,7 @@
         <file alias="lightbulb_on">resources/icons/lightbulb_on.svg</file>
         <file alias="list-add">resources/icons/list-add.svg</file>
         <file alias="list-remove">resources/icons/list-remove.svg</file>
+        <file alias="live_dot">resources/icons/live_dot.svg</file>
         <file alias="media-optical">resources/icons/media-optical.svg</file>
         <file alias="media-playback-loop">resources/icons/media-playback-loop.svg</file>
         <file alias="media-playback-pause">resources/icons/media-playback-pause.svg</file>
@@ -26,6 +27,7 @@
         <file alias="network-offline">resources/icons/network-offline.svg</file>
         <file alias="preferences-desktop-screensaver">resources/icons/preferences-desktop-screensaver.svg</file>
         <file alias="preferences-system-windows">resources/icons/preferences-system-windows.svg</file>
+        <file alias="preview_dot">resources/icons/preview_dot.svg</file>
         <file alias="process-stop">resources/icons/process-stop.svg</file>
         <file alias="refresh">resources/icons/view-refresh.svg</file>
         <file alias="screens">resources/icons/screens.svg</file>

--- a/src/staldates/ui/resources.qrc
+++ b/src/staldates/ui/resources.qrc
@@ -31,6 +31,7 @@
         <file alias="process-stop">resources/icons/process-stop.svg</file>
         <file alias="refresh">resources/icons/view-refresh.svg</file>
         <file alias="screens">resources/icons/screens.svg</file>
+        <file alias="stream">resources/icons/stream.svg</file>
         <file alias="spinner">resources/icons/spinner.gif</file>
         <file alias="status-ok">resources/icons/status-ok.svg</file>
         <file alias="status-unknown">resources/icons/status-unknown.svg</file>

--- a/src/staldates/ui/resources/AldatesX.qss
+++ b/src/staldates/ui/resources/AldatesX.qss
@@ -43,21 +43,10 @@ InputButton:disabled, OutputButton:disabled, OptionButton:disabled, ExpandingBut
   background-color: #9FA5A5;
 }
 
-OutputButton {
-  color: #1693A5;
-}
-
-OutputButton:disabled {
-  color: #9FA5A5;
-}
-
-OutputButton:pressed {
-  color: #E4E4FF;
-}
-
 OutputButton>#stateDisplay {
   font-size: 12pt;
   border-radius: 5px;
+  color: white;
 }
 
 OutputButton>#stateDisplay[highlight="true"] {

--- a/src/staldates/ui/resources/AldatesX.qss
+++ b/src/staldates/ui/resources/AldatesX.qss
@@ -54,6 +54,14 @@ OutputButton>#stateDisplay[highlight="true"] {
   color: black;
 }
 
+InputButton {
+  border: 3px solid #1693A5;
+}
+
+InputButton:pressed, InputButton:checked {
+  border-color: #E4E4FF;
+}
+
 QToolButton[isPreview="true"] {
   border: 3px solid #50FF50;
 }

--- a/src/staldates/ui/resources/icons/README.md
+++ b/src/staldates/ui/resources/icons/README.md
@@ -1,7 +1,9 @@
 Icons
 =====
 
-These icons are taken (or derived) from the Tango desktop project http://tango.freedesktop.org/
+Many of these icons are taken (or derived) from the Tango desktop project:
+
+[http://tango.freedesktop.org/]
 
 License from that page:
 

--- a/src/staldates/ui/resources/icons/live_dot.svg
+++ b/src/staldates/ui/resources/icons/live_dot.svg
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   id="svg8"
+   version="1.1"
+   viewBox="0 0 8.4666665 8.4666669"
+   height="32"
+   width="32">
+  <defs
+     id="defs2" />
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     transform="translate(0,-288.53332)"
+     id="layer1">
+    <circle
+       r="4.2333331"
+       cy="292.76666"
+       cx="4.2333331"
+       id="path4518"
+       style="fill:#ff0000;fill-opacity:1;stroke:none;stroke-width:2.15682626;stroke-linecap:square;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:stroke fill markers" />
+  </g>
+</svg>

--- a/src/staldates/ui/resources/icons/preview_dot.svg
+++ b/src/staldates/ui/resources/icons/preview_dot.svg
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   id="svg8"
+   version="1.1"
+   viewBox="0 0 8.4666665 8.4666669"
+   height="32"
+   width="32">
+  <defs
+     id="defs2" />
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     transform="translate(0,-288.53332)"
+     id="layer1">
+    <circle
+       r="4.2333331"
+       cy="292.76666"
+       cx="4.2333331"
+       id="path4518"
+       style="fill:#00ff00;fill-opacity:1;stroke:none;stroke-width:2.15682626;stroke-linecap:square;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:stroke fill markers" />
+  </g>
+</svg>

--- a/src/staldates/ui/resources/icons/stream.svg
+++ b/src/staldates/ui/resources/icons/stream.svg
@@ -1,0 +1,827 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   version="1.1"
+   id="svg2327"
+   height="48.000000px"
+   width="48.000000px">
+  <defs
+     id="defs3">
+    <linearGradient
+       id="linearGradient2329">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1.0000000;"
+         offset="0.0000000"
+         id="stop2331" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0.0000000;"
+         offset="1.0000000"
+         id="stop2333" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient2321">
+      <stop
+         style="stop-color:#7b7f7a;stop-opacity:1;"
+         offset="0"
+         id="stop2323" />
+      <stop
+         style="stop-color:#7b7f7a;stop-opacity:0;"
+         offset="1"
+         id="stop2325" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient2711">
+      <stop
+         style="stop-color:#909090;stop-opacity:1.0000000;"
+         offset="0.0000000"
+         id="stop2713" />
+      <stop
+         style="stop-color:#bebebe;stop-opacity:0.0000000;"
+         offset="1.0000000"
+         id="stop2715" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient2701">
+      <stop
+         style="stop-color:#585956;stop-opacity:1.0000000;"
+         offset="0.0000000"
+         id="stop2703" />
+      <stop
+         style="stop-color:#bbbeb8;stop-opacity:1.0000000;"
+         offset="1.0000000"
+         id="stop2705" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient2683">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop2685" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0;"
+         offset="1"
+         id="stop2687" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient2675">
+      <stop
+         style="stop-color:#5b5b97;stop-opacity:1.0000000;"
+         offset="0.0000000"
+         id="stop2677" />
+      <stop
+         style="stop-color:#1b1b43;stop-opacity:1.0000000;"
+         offset="1.0000000"
+         id="stop2679" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient2667">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1.0000000;"
+         offset="0.0000000"
+         id="stop2669" />
+      <stop
+         style="stop-color:#fcfcff;stop-opacity:0.0000000;"
+         offset="1.0000000"
+         id="stop2671" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient2454">
+      <stop
+         id="stop2456"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:1;" />
+      <stop
+         id="stop2458"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient2415">
+      <stop
+         id="stop2417"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1;" />
+      <stop
+         id="stop2419"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient2253">
+      <stop
+         id="stop2255"
+         offset="0.0000000"
+         style="stop-color:#8f8f8f;stop-opacity:1.0000000;" />
+      <stop
+         id="stop2257"
+         offset="1.0000000"
+         style="stop-color:#494949;stop-opacity:1.0000000;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient2245">
+      <stop
+         id="stop2247"
+         offset="0.0000000"
+         style="stop-color:#dde1d9;stop-opacity:1.0000000;" />
+      <stop
+         id="stop2249"
+         offset="1.0000000"
+         style="stop-color:#cacdc6;stop-opacity:1.0000000;" />
+    </linearGradient>
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="33.339787"
+       x2="34.784473"
+       y1="7.2293582"
+       x1="8.6116238"
+       gradientTransform="matrix(1.129863,0.000000,0.000000,0.885063,2.875000,1.570628)"
+       id="linearGradient2251"
+       xlink:href="#linearGradient2245" />
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="55.200756"
+       x2="34.974548"
+       y1="13.004725"
+       x1="17.698339"
+       gradientTransform="matrix(1.108069,0.000000,0.000000,0.902471,5.500000,3.875000)"
+       id="linearGradient2421"
+       xlink:href="#linearGradient2415" />
+    <radialGradient
+       gradientUnits="userSpaceOnUse"
+       r="8.7662794"
+       fy="67.501709"
+       fx="12.575710"
+       cy="67.501709"
+       cx="12.575710"
+       gradientTransform="scale(1.925808,0.519262)"
+       id="radialGradient2460"
+       xlink:href="#linearGradient2454" />
+    <linearGradient
+       xlink:href="#linearGradient2667"
+       id="linearGradient2673"
+       gradientTransform="matrix(1.238977,0.000000,0.000000,0.895955,5.090553,1.543476)"
+       x1="11.492236"
+       y1="1.6537577"
+       x2="17.199417"
+       y2="26.729263"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       xlink:href="#linearGradient2675"
+       id="linearGradient2681"
+       gradientTransform="matrix(1.174139,0.000000,0.000000,0.945431,5.221825,1.543476)"
+       x1="19.150396"
+       y1="32.622238"
+       x2="16.315819"
+       y2="8.8666229"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       xlink:href="#linearGradient2683"
+       id="linearGradient2689"
+       gradientTransform="matrix(5.705159,0.000000,0.000000,0.175280,5.500000,2.195627)"
+       x1="3.7069976"
+       y1="171.29134"
+       x2="3.7069974"
+       y2="162.45061"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       xlink:href="#linearGradient2701"
+       id="linearGradient2707"
+       gradientTransform="matrix(1.816345,0.000000,0.000000,1.278927,2.500000,-40.24508)"
+       x1="12.206709"
+       y1="53.535141"
+       x2="12.127711"
+       y2="64.892525"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       xlink:href="#linearGradient2711"
+       id="linearGradient2717"
+       x1="34.300991"
+       y1="3.9384086"
+       x2="35.520542"
+       y2="3.8451097"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       xlink:href="#linearGradient2711"
+       id="linearGradient2721"
+       gradientUnits="userSpaceOnUse"
+       x1="34.300991"
+       y1="3.9384086"
+       x2="35.520542"
+       y2="3.8451097" />
+    <linearGradient
+       xlink:href="#linearGradient2711"
+       id="linearGradient2725"
+       gradientUnits="userSpaceOnUse"
+       x1="34.300991"
+       y1="3.9384086"
+       x2="35.520542"
+       y2="3.8451097" />
+    <linearGradient
+       xlink:href="#linearGradient2711"
+       id="linearGradient2729"
+       gradientUnits="userSpaceOnUse"
+       x1="34.300991"
+       y1="3.9384086"
+       x2="35.520542"
+       y2="3.8451097" />
+    <linearGradient
+       xlink:href="#linearGradient2711"
+       id="linearGradient2733"
+       gradientUnits="userSpaceOnUse"
+       x1="34.300991"
+       y1="3.9384086"
+       x2="35.520542"
+       y2="3.8451097" />
+    <linearGradient
+       xlink:href="#linearGradient2253"
+       id="linearGradient1561"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.104397,0.000000,0.000000,0.905471,4.500000,2.875000)"
+       x1="10.390738"
+       y1="5.3817744"
+       x2="32.536823"
+       y2="31.246054" />
+    <linearGradient
+       xlink:href="#linearGradient2321"
+       id="linearGradient2327"
+       x1="-35.658386"
+       y1="33.416473"
+       x2="-35.658386"
+       y2="28.205938"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       xlink:href="#linearGradient2329"
+       id="linearGradient2337"
+       x1="-35.122688"
+       y1="34.242237"
+       x2="-35.074745"
+       y2="30.962345"
+       gradientUnits="userSpaceOnUse" />
+    <radialGradient
+       gradientUnits="userSpaceOnUse"
+       r="12.289036"
+       fy="63.965389"
+       fx="15.115514"
+       cy="63.965389"
+       cx="15.115514"
+       gradientTransform="matrix(1.64399,0,0,0.75623549,-20.796345,-15.3752)"
+       id="radialGradient4120"
+       xlink:href="#linearGradient2683" />
+    <radialGradient
+       gradientUnits="userSpaceOnUse"
+       r="29.993349"
+       fy="15.716079"
+       fx="18.247644"
+       cy="15.716079"
+       cx="18.247644"
+       gradientTransform="matrix(0.999989,0,0,1.000011,-20.796345,-5.1027898)"
+       id="radialGradient3968"
+       xlink:href="#linearGradient3962" />
+    <linearGradient
+       id="linearGradient3962">
+      <stop
+         id="stop3964"
+         offset="0.0000000"
+         style="stop-color:#d3e9ff;stop-opacity:1.0000000;" />
+      <stop
+         id="stop4134"
+         offset="0.15517241"
+         style="stop-color:#d3e9ff;stop-opacity:1.0000000;" />
+      <stop
+         id="stop4346"
+         offset="0.75000000"
+         style="stop-color:#4074ae;stop-opacity:1.0000000;" />
+      <stop
+         id="stop3966"
+         offset="1.0000000"
+         style="stop-color:#36486c;stop-opacity:1.0000000;" />
+    </linearGradient>
+    <radialGradient
+       gradientUnits="userSpaceOnUse"
+       r="43.526714"
+       fy="12.142302"
+       fx="15.601279"
+       cy="12.142302"
+       cx="15.601279"
+       gradientTransform="matrix(0.999989,0,0,1.000011,-20.796345,-5.1027898)"
+       id="radialGradient4132"
+       xlink:href="#linearGradient4126" />
+    <linearGradient
+       id="linearGradient4126">
+      <stop
+         id="stop4128"
+         offset="0.0000000"
+         style="stop-color:#ffffff;stop-opacity:1.0000000;" />
+      <stop
+         id="stop4130"
+         offset="1.0000000"
+         style="stop-color:#ffffff;stop-opacity:0.16494845;" />
+    </linearGradient>
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="21.041553"
+       x2="-22.252472"
+       y1="30.057165"
+       x1="-25.176178"
+       id="linearGradient6007"
+       xlink:href="#linearGradient2329"
+       gradientTransform="matrix(1.2865169,0,0,0.9999999,34.484693,-6.2473477)" />
+    <linearGradient
+       y2="22.661524"
+       x2="-22.113543"
+       y1="30.057165"
+       x1="-25.176178"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient6011"
+       xlink:href="#linearGradient2329"
+       gradientTransform="matrix(1.2865168,0,0,0.99999987,14.937996,0.89420693)" />
+    <radialGradient
+       r="6.7175145"
+       fy="12.493138"
+       fx="12.071323"
+       cy="12.493138"
+       cx="12.071323"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient5987"
+       xlink:href="#linearGradient2329" />
+    <linearGradient
+       y2="22.661524"
+       x2="-22.113543"
+       y1="28.337734"
+       x1="-22.822565"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient6015"
+       xlink:href="#linearGradient2329"
+       gradientTransform="matrix(1.2865167,0,0,0.99999972,19.616173,-37.525553)" />
+    <linearGradient
+       y2="21.336346"
+       x2="-21.962101"
+       y1="15.649428"
+       x1="-21.658581"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient6019"
+       xlink:href="#linearGradient2329"
+       gradientTransform="matrix(1.2571175,0,0,0.97714444,13.199632,-4.0987869)" />
+    <radialGradient
+       r="6.7175145"
+       fy="12.493138"
+       fx="12.071323"
+       cy="12.493138"
+       cx="12.071323"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient5983"
+       xlink:href="#linearGradient2329" />
+    <radialGradient
+       r="6.7175145"
+       fy="12.493138"
+       fx="12.071323"
+       cy="12.493138"
+       cx="12.071323"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient5985"
+       xlink:href="#linearGradient2329" />
+    <radialGradient
+       r="6.7175145"
+       fy="12.493138"
+       fx="12.071323"
+       cy="12.493138"
+       cx="12.071323"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient5989"
+       xlink:href="#linearGradient2329" />
+  </defs>
+  <metadata
+     id="metadata4">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+        <dc:date />
+        <dc:creator>
+          <cc:Agent>
+            <dc:title>Jakub Steiner</dc:title>
+          </cc:Agent>
+        </dc:creator>
+        <dc:subject>
+          <rdf:Bag>
+            <rdf:li>video</rdf:li>
+            <rdf:li>display</rdf:li>
+            <rdf:li>monitor</rdf:li>
+            <rdf:li>LCD</rdf:li>
+            <rdf:li>CRT</rdf:li>
+          </rdf:Bag>
+        </dc:subject>
+        <cc:license
+           rdf:resource="http://creativecommons.org/licenses/publicdomain/" />
+        <dc:source>http://jimmac.musichall.cz/</dc:source>
+      </cc:Work>
+      <cc:License
+         rdf:about="http://creativecommons.org/licenses/publicdomain/">
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#Reproduction" />
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#Distribution" />
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#DerivativeWorks" />
+      </cc:License>
+    </rdf:RDF>
+  </metadata>
+  <g
+     id="layer1">
+    <ellipse
+       ry="4.552"
+       rx="16.882174"
+       cy="35.051105"
+       cx="24.218407"
+       transform="matrix(1.050251,0,0,1.867888,-0.945558,-28.10611)"
+       id="path2452"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.50857143;fill:url(#radialGradient2460);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:0.70063692;marker:none;marker-start:none;marker-mid:none;marker-end:none" />
+    <ellipse
+       ry="3.939595"
+       rx="9.3944187"
+       cy="29.716238"
+       cx="-35.658386"
+       transform="translate(60.03339,8.07843)"
+       id="path2407"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#adb0aa;fill-opacity:1;fill-rule:evenodd;stroke:#4b4d4a;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none" />
+    <ellipse
+       ry="3.939595"
+       rx="9.3944187"
+       cy="29.716238"
+       cx="-35.658386"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient2327);stroke-width:1.15713382;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none"
+       id="path1825"
+       transform="matrix(0.902373,0,0,0.82765,56.55215,12.86792)" />
+    <ellipse
+       ry="3.939595"
+       rx="9.3944187"
+       cy="29.716238"
+       cx="-35.658386"
+       transform="matrix(0.837548,0,0,0.852655,54.17811,11.00615)"
+       id="path2983"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient2337);stroke-width:1.18333709;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none" />
+    <rect
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient2707);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.60872948;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none"
+       id="rect2699"
+       width="9.0396729"
+       height="6.3650389"
+       x="19.972397"
+       y="31.078613" />
+    <path
+       id="rect2404"
+       d="M 7.5809024,4.5706221 H 41.169097 c 0.911342,0 1.624147,0.5834818 1.666752,1.401587 l 1.332044,25.5781139 c 0.05821,1.117735 -0.901056,2.020305 -2.020305,2.020305 H 6.602412 c -1.1192491,0 -2.078514,-0.90257 -2.0203052,-2.020305 L 5.9141506,5.9722091 c 0.040284,-0.7735346 0.5475027,-1.401587 1.6667518,-1.401587 z"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient2251);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient1561);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none" />
+    <path
+       style="fill:url(#linearGradient2681);fill-opacity:1;fill-rule:evenodd;stroke:#000079;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 8.910535,7.180827 7.6683398,29.226144 H 39.318729 L 37.983712,7.274256 Z"
+       id="path2377" />
+    <path
+       id="path2393"
+       d="M 6.6774331,31.610789 H 42.10591"
+       style="fill:none;fill-opacity:0.75;fill-rule:evenodd;stroke:url(#linearGradient2689);stroke-width:0.99618119;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:0.24840764" />
+    <path
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient2421);stroke-width:0.99999964;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:0.70063692;marker:none;marker-start:none;marker-mid:none;marker-end:none"
+       d="M 7.4145985,5.5813396 41.260101,5.5435383 c 0.283697,-3.169e-4 0.559302,0.2372498 0.582105,0.6525437 l 1.361892,24.803248 c 0.05804,1.057031 -0.539749,1.785871 -1.598371,1.785871 H 7.0817583 c -1.0586228,0 -1.5930144,-0.728791 -1.5358714,-1.785871 L 6.8699773,6.505163 C 6.9086732,5.7893326 7.0363626,5.581762 7.4145985,5.5813396 Z"
+       id="path2397" />
+    <path
+       id="path2443"
+       d="M 9.211536,7.621363 8.409007,25.491693 C 19.453645,23.091063 23.83047,14.999494 37.563039,12.344943 L 37.401567,7.687427 Z"
+       style="opacity:0.53142856;fill:url(#linearGradient2673);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.25000001pt;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+    <circle
+       r="0.83968931"
+       cy="3.9384086"
+       cx="34.780815"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient2717);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none"
+       id="path2709"
+       transform="matrix(1.331237,0,0,0.658449,-5.91933,5.728866)" />
+    <circle
+       r="0.83968931"
+       cy="3.9384086"
+       cx="34.780815"
+       transform="matrix(1.331237,0,0,0.658449,-5.80573,7.83465)"
+       id="path2719"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient2721);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none" />
+    <circle
+       r="0.83968931"
+       cy="3.9384086"
+       cx="34.780815"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient2725);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none"
+       id="path2723"
+       transform="matrix(1.331237,0,0,0.658449,-5.69213,9.83465)" />
+    <circle
+       r="0.83968931"
+       cy="3.9384086"
+       cx="34.780815"
+       transform="matrix(1.331237,0,0,0.658449,-5.57853,11.83465)"
+       id="path2727"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient2729);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none" />
+    <circle
+       r="0.83968931"
+       cy="3.9384086"
+       cx="34.780815"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient2733);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none"
+       id="path2731"
+       transform="matrix(1.331237,0,0,0.658449,-5.46493,13.83465)" />
+    <path
+       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:0.9029026px;font-family:'Bitstream Vera Sans';writing-mode:lr-tb;text-anchor:start;fill:#4a4a4a;fill-opacity:1;stroke:none;stroke-width:1.00000003pt;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 22.5,30.192666 h 0.281716 c 0.08376,1e-6 0.147985,0.01866 0.19266,0.05599 0.04497,0.03703 0.06745,0.08994 0.06745,0.158714 -1e-6,0.06907 -0.02248,0.122268 -0.06745,0.159595 -0.04467,0.03703 -0.108895,0.05555 -0.19266,0.05555 h -0.111981 v 0.22837 H 22.5 v -0.658219 m 0.169735,0.123003 v 0.183843 h 0.0939 c 0.03292,0 0.05834,-0.0079 0.07627,-0.02381 0.01793,-0.01617 0.02689,-0.03894 0.02689,-0.06834 0,-0.02939 -0.009,-0.05202 -0.02689,-0.06789 -0.01793,-0.01587 -0.04335,-0.02381 -0.07627,-0.02381 h -0.0939 m 0.792244,-0.0119 c -0.05173,1e-6 -0.09185,0.01911 -0.120358,0.05731 -0.02851,0.03821 -0.04276,0.092 -0.04276,0.161359 0,0.06907 0.01425,0.122709 0.04276,0.160918 0.02851,0.03821 0.06863,0.05731 0.120358,0.05731 0.05202,0 0.09229,-0.0191 0.120799,-0.05731 0.02851,-0.03821 0.04276,-0.09185 0.04276,-0.160918 -10e-7,-0.06936 -0.01425,-0.123149 -0.04276,-0.161359 -0.02851,-0.03821 -0.06878,-0.05731 -0.120799,-0.05731 m 0,-0.123003 c 0.105808,1e-6 0.188692,0.03027 0.248651,0.09082 0.05996,0.06055 0.08994,0.144165 0.08994,0.250855 -1e-6,0.106397 -0.02998,0.189868 -0.08994,0.250414 -0.05996,0.06055 -0.142843,0.09082 -0.248651,0.09082 -0.105515,0 -0.188399,-0.03027 -0.248651,-0.09082 -0.05996,-0.06055 -0.08994,-0.144017 -0.08994,-0.250414 0,-0.10669 0.02998,-0.190309 0.08994,-0.250855 0.06025,-0.06055 0.143136,-0.09082 0.248651,-0.09082 m 0.466441,0.0119 h 0.189574 l 0.239393,0.451451 v -0.451451 h 0.160918 v 0.658219 H 24.32873 l -0.239392,-0.451451 v 0.451451 H 23.92842 v -0.658219 m 0.663069,0 h 0.185606 l 0.149896,0.234543 0.149896,-0.234543 h 0.186048 l -0.250856,0.380912 v 0.277307 h -0.169735 v -0.277307 l -0.250855,-0.380912"
+       id="text2735" />
+    <g
+       transform="matrix(0.49548607,0,0,0.49548607,22.011799,8.9620942)"
+       id="g1129">
+      <ellipse
+         style="fill:url(#radialGradient4120);fill-opacity:1;stroke:none;stroke-width:1.11500847;stroke-opacity:1"
+         id="path4112"
+         cx="4.0534067"
+         cy="32.997719"
+         rx="20.203051"
+         ry="9.2934084" />
+      <path
+         style="fill:url(#radialGradient3968);fill-opacity:1;fill-rule:nonzero;stroke:#39396c;stroke-miterlimit:4;stroke-opacity:1"
+         d="m 23.163508,18.382709 c 0,10.709718 -8.682103,19.391723 -19.390348,19.391723 -10.709226,0 -19.390839,-8.682103 -19.390839,-19.391723 0,-10.7092268 8.681613,-19.3903471 19.390839,-19.3903471 10.708245,0 19.390348,8.6811203 19.390348,19.3903471 z"
+         id="path3214" />
+      <g
+         id="g4136"
+         style="opacity:1;fill:#204a87;fill-opacity:0.71345029;fill-rule:nonzero;stroke:none;stroke-miterlimit:4"
+         transform="matrix(0.982371,0,0,0.982371,-20.675266,-4.8698758)">
+        <g
+           id="g4138"
+           style="fill:#204a87">
+          <g
+             id="g4142"
+             style="fill:#204a87">
+            <path
+               d="m 44.0713,20.7144 c 0,0.2627 0,0 0,0 l -0.5449,0.6172 c -0.334,-0.3936 -0.709,-0.7246 -1.0898,-1.0703 l -0.8359,0.123 -0.7637,-0.8633 v 1.0684 l 0.6543,0.4951 0.4355,0.4932 0.582,-0.6582 c 0.1465,0.2744 0.291,0.5488 0.4365,0.8232 v 0.8223 l -0.6553,0.7402 -1.1992,0.8232 -0.9082,0.9063 -0.582,-0.6602 0.291,-0.7402 -0.5811,-0.6582 -0.9814,-2.0977 -0.8359,-0.9453 -0.2188,0.2461 0.3281,1.1934 0.6172,0.6992 c 0.3525,1.0176 0.7012,1.9902 1.1641,2.9629 0.7178,0 1.3945,-0.0762 2.1074,-0.166 v 0.5762 l -0.8721,2.1392 -0.7998,0.9043 -0.6543,1.4004 c 0,0.7676 0,1.5352 0,2.3027 l 0.2188,0.9063 -0.3633,0.4102 -0.8008,0.4941 -0.8359,0.6992 0.6914,0.7813 -0.9453,0.8242 0.1816,0.5332 -1.418,1.6055 h -0.9443 l -0.7998,0.4941 H 33.6396 V 38.2814 L 33.4228,36.963 c -0.2813,-0.8262 -0.5742,-1.6465 -0.8721,-2.4668 0,-0.6055 0.0361,-1.2051 0.0723,-1.8105 l 0.3643,-0.8223 -0.5098,-0.9883 0.0371,-1.3574 -0.6914,-0.7813 0.3457,-1.1309 -0.5625,-0.6382 H 30.624 l -0.3271,-0.3701 -0.9814,0.6177 -0.3994,-0.4536 -0.9092,0.7817 c -0.6172,-0.6997 -1.2354,-1.3989 -1.8535,-2.0981 l -0.7266,-1.7285 0.6543,-0.9863 -0.3633,-0.4111 0.7988,-1.8936 c 0.6563,-0.8164 1.3418,-1.5996 2.0352,-2.3857 l 1.2363,-0.3291 1.3809,-0.1641 0.9453,0.2471 1.3447,1.3564 0.4727,-0.5342 0.6533,-0.082 1.2363,0.4111 h 0.9453 l 0.6543,-0.5762 0.291,-0.4111 -0.6553,-0.4111 -1.0908,-0.082 c -0.3027,-0.4199 -0.584,-0.8613 -0.9434,-1.2344 l -0.3643,0.1641 -0.1455,1.0703 -0.6543,-0.7402 -0.1445,-0.8242 -0.7266,-0.5742 h -0.292 l 0.7275,0.8223 -0.291,0.7402 -0.5811,0.1641 0.3633,-0.7402 -0.6553,-0.3281 -0.5801,-0.6582 -1.0918,0.2461 -0.1445,0.3281 -0.6543,0.4121 -0.3633,0.9053 -0.9082,0.4521 -0.4004,-0.4521 h -0.4355 v -1.4814 l 0.9453,-0.4941 h 0.7266 l -0.1465,-0.5752 -0.5801,-0.5762 0.9805,-0.2061 0.5449,-0.6162 0.4355,-0.7412 h 0.8008 l -0.2188,-0.5752 0.5098,-0.3291 v 0.6582 l 1.0898,0.2461 1.0898,-0.9043 0.0732,-0.4121 0.9443,-0.6577 c -0.3418,0.0425 -0.6836,0.0737 -1.0176,0.1646 V 9.9766 L 34.2213,9.1538 H 33.858 l -0.7984,0.7402 -0.2188,0.4116 0.2188,0.5767 -0.3643,0.9863 -0.5811,-0.3291 -0.5078,-0.5752 -0.8008,0.5752 -0.291,-1.3159 1.3809,-0.9048 V 8.8247 l 0.873,-0.5757 1.3809,-0.3296 0.9453,0.3296 1.7441,0.3291 -0.4355,0.4932 H 35.458 l 0.9453,0.9873 0.7266,-0.8223 0.2207,-0.3618 c 0,0 2.7871,2.498 4.3799,5.2305 1.5928,2.7334 2.3408,5.9551 2.3408,6.6094 z"
+               id="path4144"
+               style="fill:#204a87" />
+          </g>
+        </g>
+        <g
+           id="g4146"
+           style="fill:#204a87">
+          <g
+             id="g4150"
+             style="fill:#204a87">
+            <path
+               d="m 26.0703,9.2363 -0.0732,0.4932 0.5098,0.3291 0.8711,-0.5757 -0.4355,-0.4937 -0.582,0.3296 -0.29,-0.0825"
+               id="path4152"
+               style="fill:#204a87" />
+          </g>
+        </g>
+        <g
+           id="g4154"
+           style="fill:#204a87">
+          <g
+             id="g4158"
+             style="fill:#204a87">
+            <path
+               d="m 26.8701,5.8633 -1.8906,-0.7407 -2.1797,0.2466 -2.6904,0.7402 -0.5088,0.4941 1.6719,1.1514 v 0.6582 l -0.6543,0.6582 0.873,1.729 0.5801,-0.3301 0.7285,-1.1514 c 1.123,-0.3472 2.1299,-0.7407 3.1973,-1.2344 l 0.873,-2.2212"
+               id="path4160"
+               style="fill:#204a87" />
+          </g>
+        </g>
+        <g
+           id="g4162"
+           style="fill:#204a87">
+          <g
+             id="g4166"
+             style="fill:#204a87">
+            <path
+               d="m 28.833,12.7749 -0.291,-0.7412 -0.5098,0.165 0.1465,0.9043 0.6543,-0.3281"
+               id="path4168"
+               style="fill:#204a87" />
+          </g>
+        </g>
+        <g
+           id="g4170"
+           style="fill:#204a87">
+          <g
+             id="g4174"
+             style="fill:#204a87">
+            <path
+               d="m 29.123,12.6089 -0.1455,0.9883 0.7998,-0.165 0.5811,-0.5752 -0.5088,-0.4941 C 29.6787,11.9078 29.4824,11.483 29.2685,11.0465 H 28.833 v 0.4932 l 0.29,0.3291 v 0.7402"
+               id="path4176"
+               style="fill:#204a87" />
+          </g>
+        </g>
+        <g
+           id="g4178"
+           style="fill:#204a87">
+          <g
+             id="g4182"
+             style="fill:#204a87">
+            <path
+               d="m 18.3652,28.2422 -0.582,-1.1523 -1.0903,-0.2466 -0.5815,-1.5625 -1.4536,0.1641 -1.2354,-0.9043 -1.3091,1.1514 v 0.1816 c -0.396,-0.1143 -0.8828,-0.1299 -1.2354,-0.3467 l -0.291,-0.8223 v -0.9053 l -0.8721,0.082 c 0.0728,-0.5762 0.145,-1.1514 0.2183,-1.7275 H 9.4238 L 8.9155,22.812 8.4062,23.0581 7.6791,22.6479 7.6063,21.7426 7.7518,20.7553 8.8426,19.933 h 0.8721 l 0.145,-0.4941 1.0903,0.2461 0.7998,0.9883 0.1455,-1.6465 1.3813,-1.1514 0.5088,-1.2344 1.0176,-0.4111 0.5815,-0.8223 1.3081,-0.248 0.6548,-0.9863 c -0.6543,0 -1.3086,0 -1.9629,0 l 1.2358,-0.5762 h 0.8716 l 1.2363,-0.4121 0.1455,-0.4922 -0.4365,-0.4121 -0.5088,-0.165 0.1455,-0.4932 -0.3633,-0.7402 -0.8726,0.3281 0.1455,-0.6577 -1.0176,-0.5762 -0.7993,1.3979 0.0723,0.4941 -0.7993,0.3301 -0.5093,1.0693 -0.2178,-0.9873 -1.3813,-0.5762 -0.2183,-0.7402 1.8174,-1.0703 0.7998,-0.7402 0.0728,-0.9048 -0.436,-0.2471 -0.5815,-0.0825 -0.3633,0.9053 c 0,0 -0.6079,0.1191 -0.7642,0.1577 -1.9961,1.8394 -6.0293,5.8101 -6.9663,13.3062 0.0371,0.1738 0.6792,1.1816 0.6792,1.1816 l 1.5264,0.9043 1.5264,0.4121 0.6548,0.8232 1.0171,0.7402 0.5815,-0.082 0.436,0.1963 v 0.1328 l -0.5811,1.563 -0.4365,0.6582 0.1455,0.3301 -0.3633,1.2324 1.3086,2.3867 1.3081,1.1523 0.582,0.8223 -0.0732,1.7285 0.4365,0.9863 -0.4365,1.8926 c 0,0 -0.0342,-0.0117 0.0215,0.1777 0.0562,0.1895 2.3291,1.4512 2.4736,1.3438 0.144,-0.1094 0.2671,-0.2051 0.2671,-0.2051 l -0.145,-0.4102 0.5811,-0.5762 0.2183,-0.5762 0.9453,-0.3301 0.7266,-1.8105 -0.2178,-0.4922 0.5078,-0.7402 1.0908,-0.248 0.582,-1.3164 -0.1455,-1.6445 0.8721,-1.2344 0.1455,-1.2344 C 20.7331,29.4607 19.5495,28.8513 18.365,28.242"
+               id="path4184"
+               style="fill:#204a87" />
+          </g>
+        </g>
+        <g
+           id="g4186"
+           style="fill:#204a87">
+          <g
+             id="g4190"
+             style="fill:#204a87">
+            <path
+               d="m 16.7656,9.5649 0.7266,0.4937 h 0.582 V 9.4829 l -0.7266,-0.3291 -0.582,0.4111"
+               id="path4192"
+               style="fill:#204a87" />
+          </g>
+        </g>
+        <g
+           id="g4194"
+           style="fill:#204a87">
+          <g
+             id="g4198"
+             style="fill:#204a87">
+            <path
+               d="M 14.876,8.9072 14.5122,9.812 h 0.7271 L 15.6031,8.9892 C 15.9166,8.7675 16.2286,8.5444 16.5479,8.331 l 0.7271,0.2471 c 0.4844,0.3291 0.9688,0.6582 1.4536,0.9868 L 19.4561,8.9072 18.6558,8.5781 18.292,7.8374 16.9111,7.6728 16.8383,7.2612 16.184,7.4262 15.8936,8.002 15.5298,7.2613 l -0.145,0.3291 0.0728,0.8228 -0.5816,0.494"
+               id="path4200"
+               style="fill:#204a87" />
+          </g>
+        </g>
+        <g
+           id="g4202"
+           style="fill:#204a87">
+          <g
+             style="opacity:0.75;fill:#204a87"
+             id="g4204">
+            <path
+               id="path4206"
+               d=""
+               style="fill:#204a87" />
+          </g>
+          <g
+             id="g4208"
+             style="fill:#204a87">
+            <path
+               id="path4210"
+               d=""
+               style="fill:#204a87" />
+          </g>
+        </g>
+        <g
+           id="g4212"
+           style="fill:#204a87">
+          <g
+             style="opacity:0.75;fill:#204a87"
+             id="g4214">
+            <path
+               id="path4216"
+               d=""
+               style="fill:#204a87" />
+          </g>
+          <g
+             id="g4218"
+             style="fill:#204a87">
+            <path
+               id="path4220"
+               d=""
+               style="fill:#204a87" />
+          </g>
+        </g>
+        <g
+           id="g4222"
+           style="fill:#204a87">
+          <g
+             id="g4226"
+             style="fill:#204a87">
+            <path
+               d="M 17.4922,6.8496 17.856,6.521 18.5831,6.3564 c 0.498,-0.2422 0.998,-0.4053 1.5264,-0.5762 l -0.29,-0.4937 -0.9385,0.1348 -0.4434,0.4419 -0.731,0.106 -0.6499,0.3052 -0.3159,0.1528 -0.1929,0.2583 0.9443,0.1641"
+               id="path4228"
+               style="fill:#204a87" />
+          </g>
+        </g>
+        <g
+           id="g4230"
+           style="fill:#204a87">
+          <g
+             id="g4234"
+             style="fill:#204a87">
+            <path
+               d="m 18.7285,14.6665 0.4365,-0.6582 -0.6548,-0.4932 0.2183,1.1514"
+               id="path4236"
+               style="fill:#204a87" />
+          </g>
+        </g>
+      </g>
+      <path
+         style="opacity:0.39560439;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:url(#radialGradient4132);stroke-miterlimit:4;stroke-opacity:1"
+         d="m 22.178748,18.382744 c 0,10.16582 -8.241178,18.406906 -18.4056,18.406906 -10.165354,0 -18.406067,-8.241179 -18.406067,-18.406906 0,-10.1653538 8.240713,-18.40559981 18.406067,-18.40559981 10.164422,0 18.4056,8.24024601 18.4056,18.40559981 z"
+         id="path4122" />
+      <ellipse
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:none;fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient6007);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none"
+         id="path5991"
+         transform="rotate(28.460691)"
+         cx="10.60494"
+         cy="14.794204"
+         rx="20.240932"
+         ry="9.457552" />
+      <ellipse
+         transform="rotate(-43.10261)"
+         id="path6009"
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:none;fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient6011);stroke-width:0.99999994;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none"
+         cx="-8.9417543"
+         cy="21.935757"
+         rx="20.240931"
+         ry="9.457552" />
+      <g
+         transform="matrix(-1.045772,0.767251,0.767251,1.045772,14.820165,-27.24675)"
+         id="g4933">
+        <circle
+           transform="translate(14.95026,22.93047)"
+           id="path4935"
+           style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:url(#radialGradient5987);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none"
+           cx="12.071323"
+           cy="12.493138"
+           r="6.7175145" />
+        <circle
+           style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none"
+           id="path4937"
+           transform="matrix(0.308271,0,0,0.308271,23.30035,31.57234)"
+           cx="12.071323"
+           cy="12.493138"
+           r="6.7175145" />
+      </g>
+      <ellipse
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:none;fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient6015);stroke-width:0.99999982;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none"
+         id="path6013"
+         transform="rotate(-174.37239)"
+         cx="-4.2635756"
+         cy="-16.484007"
+         rx="20.240929"
+         ry="9.45755" />
+      <ellipse
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:none;fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient6019);stroke-width:0.99999928;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none"
+         id="path6017"
+         transform="matrix(0.73014176,-0.6832957,0.68331862,0.7301203,0,0)"
+         cx="-10.134423"
+         cy="16.461851"
+         rx="19.778389"
+         ry="9.241395" />
+      <g
+         id="g5075"
+         transform="matrix(-0.806276,0.59154,0.59154,0.806276,-8.4107048,-23.132)">
+        <circle
+           transform="translate(14.95026,22.93047)"
+           id="path5077"
+           style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:url(#radialGradient5983);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none"
+           cx="12.071323"
+           cy="12.493138"
+           r="6.7175145" />
+        <circle
+           style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none"
+           id="path5079"
+           transform="matrix(0.308271,0,0,0.308271,23.30035,31.57234)"
+           cx="12.071323"
+           cy="12.493138"
+           r="6.7175145" />
+      </g>
+      <g
+         transform="matrix(-0.806276,0.59154,0.59154,0.806276,-7.297245,-36.60301)"
+         id="g4945">
+        <circle
+           style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:url(#radialGradient5985);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none"
+           id="path4947"
+           transform="translate(14.95026,22.93047)"
+           cx="12.071323"
+           cy="12.493138"
+           r="6.7175145" />
+        <circle
+           transform="matrix(0.308271,0,0,0.308271,23.30035,31.57234)"
+           id="path4949"
+           style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none"
+           cx="12.071323"
+           cy="12.493138"
+           r="6.7175145" />
+      </g>
+      <g
+         style="opacity:1"
+         id="g4939"
+         transform="matrix(-0.870227,0.638572,0.638458,0.870381,4.408685,-40.41557)">
+        <circle
+           style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:url(#radialGradient5989);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none"
+           id="path4941"
+           transform="translate(14.95026,22.93047)"
+           cx="12.071323"
+           cy="12.493138"
+           r="6.7175145" />
+        <circle
+           transform="matrix(0.308271,0,0,0.308271,23.30035,31.57234)"
+           id="path4943"
+           style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none"
+           cx="12.071323"
+           cy="12.493138"
+           r="6.7175145" />
+      </g>
+    </g>
+  </g>
+</svg>

--- a/src/staldates/ui/widgets/AdvancedMenu.py
+++ b/src/staldates/ui/widgets/AdvancedMenu.py
@@ -6,6 +6,7 @@ from staldates.ui.widgets.Preferences import PreferencesWidget
 from staldates.ui.widgets.Screens import ScreenWithBackButton
 from staldates.ui._version import __version__ as _ui_version
 from staldates.VisualsSystem import with_atem
+from staldates.preferences import Preferences
 
 
 class AdvancedMenu(ScreenWithBackButton):
@@ -31,7 +32,13 @@ class AdvancedMenu(ScreenWithBackButton):
         bottom_row = QHBoxLayout()
 
         lblVersion = QLabel()
-        lblVersion.setText("av-control version {0}\navx version {1}".format(_ui_version, _avx_version))
+        lblVersion.setText(
+            "av-control version {}\navx version {}\nControlling M/E bus {}".format(
+                _ui_version,
+                _avx_version,
+                Preferences.get('atem_me', 1)
+            )
+        )
         bottom_row.addWidget(lblVersion)
 
         log = ExpandingButton()

--- a/src/staldates/ui/widgets/AllInputsPanel.py
+++ b/src/staldates/ui/widgets/AllInputsPanel.py
@@ -41,9 +41,12 @@ class AllInputsPanel(QWidget):
 
         self.setLayout(self.layout)
 
-        self.switcherState.inputsChanged.connect(self.setSources)
-        self.setSources()
-        self.displayInputs()
+        def handle_inputs_changed():
+            self.setSources()
+            self.displayInputs()
+
+        self.switcherState.inputsChanged.connect(handle_inputs_changed)
+        handle_inputs_changed()
 
     def setSources(self):
         self.sources = [vs for vs in VideoSource if vs in self.switcherState.inputs.keys()]

--- a/src/staldates/ui/widgets/AllInputsPanel.py
+++ b/src/staldates/ui/widgets/AllInputsPanel.py
@@ -9,9 +9,8 @@ class AllInputsPanel(QWidget):
 
     inputSelected = Signal(Input)
 
-    def __init__(self, switcherState, parent=None):
+    def __init__(self, switcherState, me=1, parent=None):
         super(AllInputsPanel, self).__init__(parent)
-
         self.switcherState = switcherState
         self.selectedInput = None
         self.page = 0
@@ -33,7 +32,7 @@ class AllInputsPanel(QWidget):
         for col in range(5):
             self.layout.setColumnStretch(col, 1)
             for row in range(3):
-                btn = InputButton(None)
+                btn = InputButton(None, main_me=me)
                 self.layout.addWidget(btn, row * 2, col, 2, 1)
                 self.input_buttons.addButton(btn)
                 btn.clicked.connect(self.selectInput)

--- a/src/staldates/ui/widgets/Buttons.py
+++ b/src/staldates/ui/widgets/Buttons.py
@@ -145,9 +145,10 @@ class IDedButton(ExpandingButton):
 
 class OutputButton(LongPressButtonMixin, ExpandingButton):
 
-    def __init__(self, myOutput, parent=None):
+    def __init__(self, myOutput, main_me=VideoSource.ME_1_PROGRAM, parent=None):
         super(OutputButton, self).__init__(parent)
         self.setToolButtonStyle(Qt.ToolButtonStyle.ToolButtonIconOnly)  # Sneakily hide our actual text
+        self._main_me = main_me
 
         self.textDisplay = QLabel()
         self.stateDisplay = QLabel()
@@ -171,7 +172,8 @@ class OutputButton(LongPressButtonMixin, ExpandingButton):
 
         if self.output.source and hasattr(self.output.source, "label"):
             self.stateDisplay.setText(self.output.source.label)
-            self.stateDisplay.setProperty("highlight", (self.output.source.source != VideoSource.ME_1_PROGRAM))
+            # Highlight if this output is not showing the M/E we're controlling
+            self.stateDisplay.setProperty("highlight", (self.output.source.source != self._main_me))
         else:
             self.stateDisplay.setText("-")
             self.stateDisplay.setProperty("highlight", False)

--- a/src/staldates/ui/widgets/Buttons.py
+++ b/src/staldates/ui/widgets/Buttons.py
@@ -180,7 +180,6 @@ class OutputButton(LongPressButtonMixin, ExpandingButton):
 
     def setText(self, text):
         self.textDisplay.setText(text)
-        super(OutputButton, self).setText(text)
 
 
 class OptionButton(ExpandingButton):

--- a/src/staldates/ui/widgets/Buttons.py
+++ b/src/staldates/ui/widgets/Buttons.py
@@ -81,8 +81,9 @@ def _add_line_breaks(text, every_n=10):
 
 class InputButton(LongPressButtonMixin, ExpandingButton):
 
-    def __init__(self, myInput, parent=None):
+    def __init__(self, myInput, main_me=1, parent=None):
         super(InputButton, self).__init__(parent)
+        self.main_me = main_me
         self.setCheckable(True)
         self.setToolButtonStyle(Qt.ToolButtonStyle.ToolButtonTextUnderIcon)
         self.input = None
@@ -106,16 +107,18 @@ class InputButton(LongPressButtonMixin, ExpandingButton):
         else:
             self.setIcon(QIcon())
 
-        self.setProperty("isLive", self.input.isLive)
-        self.setProperty("isPreview", self.input.isPreview)
+        me_tally = self.input.tally.get(self.main_me - 1, {'pgm': False, 'pvw': False})
+
+        self.setProperty("isLive", me_tally['pgm'])
+        self.setProperty("isPreview", me_tally['pvw'])
 
         self.style().unpolish(self)
         self.style().polish(self)
 
 
 class FlashingInputButton(InputButton):
-    def __init__(self, myInput, parent=None):
-        super(FlashingInputButton, self).__init__(myInput, parent)
+    def __init__(self, myInput, main_me=1, parent=None):
+        super(FlashingInputButton, self).__init__(myInput, main_me, parent)
         self.flashing = False
         self._flashState = 0
         self._timer = QTimer()

--- a/src/staldates/ui/widgets/Buttons.py
+++ b/src/staldates/ui/widgets/Buttons.py
@@ -1,6 +1,6 @@
 from avx.devices.net.atem.constants import VideoSource
 from PySide.QtGui import QLabel, QToolButton, QSizePolicy, QVBoxLayout, QImage,\
-    QPainter, QPixmap, QIcon
+    QPainter, QPixmap, QIcon, QHBoxLayout
 from PySide.QtCore import Qt, QSize, Signal, QEvent, QTimer
 from PySide.QtSvg import QSvgRenderer
 
@@ -86,6 +86,24 @@ class InputButton(LongPressButtonMixin, ExpandingButton):
         self.main_me = main_me
         self.setCheckable(True)
         self.setToolButtonStyle(Qt.ToolButtonStyle.ToolButtonTextUnderIcon)
+
+        layout = QHBoxLayout()
+        self.previewDot = QLabel()
+        self.previewDot.setPixmap(pixmap_from_svg(':icons/preview_dot', 16, 16))
+        self.previewDot.setVisible(False)
+        layout.addWidget(self.previewDot)
+        layout.setAlignment(self.previewDot, Qt.AlignTop)
+
+        layout.addStretch()
+
+        self.liveDot = QLabel()
+        self.liveDot.setPixmap(pixmap_from_svg(':icons/live_dot', 16, 16))
+        self.liveDot.setVisible(False)
+        layout.addWidget(self.liveDot)
+        layout.setAlignment(self.liveDot, Qt.AlignTop)
+
+        self.setLayout(layout)
+
         self.input = None
         self.setInput(myInput)
 
@@ -111,6 +129,17 @@ class InputButton(LongPressButtonMixin, ExpandingButton):
 
         self.setProperty("isLive", me_tally['pgm'])
         self.setProperty("isPreview", me_tally['pvw'])
+
+        isPreviewElsewhere = False
+        isLiveElsewhere = False
+        for me, tally in self.input.tally.iteritems():
+            if me != self.main_me - 1:
+                if tally['pvw']:
+                    isPreviewElsewhere = True
+                if tally['pgm']:
+                    isLiveElsewhere = True
+        self.previewDot.setVisible(isPreviewElsewhere)
+        self.liveDot.setVisible(isLiveElsewhere)
 
         self.style().unpolish(self)
         self.style().polish(self)
@@ -198,12 +227,15 @@ class OptionButton(ExpandingButton):
 class SvgButton(ExpandingButton):
     def __init__(self, svgImage, width, height, parent=None):
         super(SvgButton, self).__init__(parent)
-        svg_renderer = QSvgRenderer(svgImage)
-        image = QImage(width, height, QImage.Format_ARGB32)
-        # Set the ARGB to 0 to prevent rendering artifacts
-        image.fill(0x00000000)
-        svg_renderer.render(QPainter(image))
-        pixmap = QPixmap.fromImage(image)
-        icon = QIcon(pixmap)
+        icon = QIcon(pixmap_from_svg(svgImage, width, height))
         self.setIcon(icon)
         self.setIconSize(QSize(width, height))
+
+
+def pixmap_from_svg(svgImage, width, height):
+    svg_renderer = QSvgRenderer(svgImage)
+    image = QImage(width, height, QImage.Format_ARGB32)
+    # Set the ARGB to 0 to prevent rendering artifacts
+    image.fill(0x00000000)
+    svg_renderer.render(QPainter(image))
+    return QPixmap.fromImage(image)

--- a/src/staldates/ui/widgets/FadeToBlackControl.py
+++ b/src/staldates/ui/widgets/FadeToBlackControl.py
@@ -5,10 +5,11 @@ from PySide.QtCore import Qt
 
 
 class FadeToBlackControl(QWidget):
-    def __init__(self, ftb, atem, parent=None):
+    def __init__(self, ftb, atem, me=1, parent=None):
         super(FadeToBlackControl, self).__init__(parent)
         self.atem = atem
         self.ftb = ftb
+        self.me = me
 
         layout = QGridLayout()
 
@@ -31,8 +32,8 @@ class FadeToBlackControl(QWidget):
         self.ftb.activeChanged.connect(self.btnFade.setChecked)
 
         if self.atem:
-            self.rate.valueChanged.connect(self.atem.setFadeToBlackRate)
-            self.btnFade.clicked.connect(self.atem.performFadeToBlack)
+            self.rate.valueChanged.connect(lambda v: self.atem.setFadeToBlackRate(v, me=self.me))
+            self.btnFade.clicked.connect(lambda: self.atem.performFadeToBlack(me=self.me))
 
         layout.setRowStretch(0, 1)
         layout.setRowStretch(1, 1)

--- a/src/staldates/ui/widgets/OutputsGrid.py
+++ b/src/staldates/ui/widgets/OutputsGrid.py
@@ -1,6 +1,7 @@
 from PySide.QtGui import QFrame, QGridLayout, QLabel
 from staldates.ui.widgets.Buttons import OutputButton, ExpandingButton
 from PySide.QtCore import Signal, QSignalMapper, Qt
+from avx.devices.net.atem.constants import VideoSource
 
 
 class MainMixControl(QFrame):
@@ -39,8 +40,10 @@ class OutputsGrid(QFrame):
     selected = Signal(int)
     sendMain = Signal(int)
 
-    def __init__(self, switcherState, parent=None):
+    def __init__(self, switcherState, me=1, parent=None):
         super(OutputsGrid, self).__init__(parent)
+        me_name = 'ME_{}_PROGRAM'.format(me)
+        self.me = getattr(VideoSource, me_name)
 
         self.signalMapper = QSignalMapper(self)
         self.longPressSignalMapper = QSignalMapper(self)
@@ -56,7 +59,7 @@ class OutputsGrid(QFrame):
         self.aux_buttons = []
 
         for idx, output in switcherState.outputs.iteritems():
-            ob = OutputButton(output)
+            ob = OutputButton(output, self.me)
             layout.addWidget(ob, 1 + (idx / 2), idx % 2)
             ob.clicked.connect(self.signalMapper.map)
             self.signalMapper.setMapping(ob, idx)

--- a/src/staldates/ui/widgets/OverlayControl.py
+++ b/src/staldates/ui/widgets/OverlayControl.py
@@ -8,12 +8,13 @@ from staldates.ui.widgets.TouchSpinner import FrameRateTouchSpinner
 
 class OverlayControl(QWidget):
 
-    def __init__(self, dsk, atem, parent=None):
+    def __init__(self, usk, mixTransition, atem, parent=None):
         super(OverlayControl, self).__init__(parent)
         self.atem = atem
-        self.dsk = dsk
+        self.usk = usk
+        self.mixTransition = mixTransition
 
-        dsk.changedState.connect(self.update_from_dsk)
+        usk.changedState.connect(self.update_from_usk)
 
         layout = QGridLayout()
 
@@ -34,15 +35,15 @@ class OverlayControl(QWidget):
 
         layout.addWidget(self.autoButton, 2, 1, 2, 1)
 
-        lblRate = QLabel("Rate:")
+        lblRate = QLabel("Fade rate:")
         lblRate.setAlignment(Qt.AlignHCenter | Qt.AlignBottom)
         layout.addWidget(lblRate, 2, 0)
 
         self.rate = FrameRateTouchSpinner()
         self.rate.setMinimum(1)
         self.rate.setMaximum(250)
-        self.rate.setValue(25)
         self.rate.valueChanged.connect(self.setRate)
+        self.mixTransition.changedProps.connect(self.update_from_mix_transition)
         layout.addWidget(self.rate, 3, 0)
 
         layout.setRowStretch(0, 1)
@@ -51,31 +52,66 @@ class OverlayControl(QWidget):
         layout.setRowStretch(3, 1)
 
         self.resetParams()
-        self.update_from_dsk()
+        self.update_from_usk()
+        self.update_from_mix_transition()
 
         self.setLayout(layout)
 
-    def update_from_dsk(self):
-        self.onAirButton.setChecked(self.dsk.onAir)
-        self.onAirButton.setProperty("isLive", self.dsk.onAir)
+    def update_from_usk(self):
+        self.onAirButton.setChecked(self.usk.onAir)
+        self.onAirButton.setProperty("isLive", self.usk.onAir)
         self.onAirButton.style().unpolish(self.onAirButton)
         self.onAirButton.style().polish(self.onAirButton)
-        self.rate.setValue(self.dsk.rate)
 
-    @with_atem
-    def setOnAir(self):
-        self.atem.setDSKOnAir(self.dsk.idx, self.onAirButton.isChecked())
-
-    @with_atem
-    def takeAuto(self):
-        self.atem.performDSKAuto(self.dsk.idx)
+    def update_from_mix_transition(self):
+        print self.mixTransition
+        self.rate.setValue(self.mixTransition.rate)
 
     @with_atem
     def setRate(self, rate):
-        self.atem.setDSKRate(self.dsk.idx, rate)
+        self.atem.setMixTransitionRate(
+            rate,
+            self.usk.me_index + 1
+        )
+
+    @with_atem
+    def setOnAir(self):
+        self.atem.setUSKOnAir(
+            self.usk.me_index + 1,
+            self.usk.keyer_index + 1,
+            self.onAirButton.isChecked()
+        )
+
+    @with_atem
+    def takeAuto(self):
+        self.atem.setNextTransition(
+            TransitionStyle.MIX,
+            bkgd=False,
+            key1=self.usk.keyer_index == 0,
+            key2=self.usk.keyer_index == 1,
+            key3=self.usk.keyer_index == 2,
+            key4=self.usk.keyer_index == 3,
+            me=self.me
+        )
+        self.atem.performAutoTake(me=self.me)
 
     @with_atem
     def resetParams(self):
-        self.atem.setDSKFillSource(self.dsk.idx, VideoSource.INPUT_5)
-        self.atem.setDSKKeySource(self.dsk.idx, VideoSource.INPUT_5)
-        self.atem.setDSKParams(self.dsk.idx, preMultiplied=False, gain=500, clip=210)
+        self.atem.setUSKFillSource(
+            self.usk.me_index + 1,
+            self.usk.keyer_index + 1,
+            VideoSource.INPUT_5
+        )
+        self.atem.setUSKKeySource(
+            self.usk.me_index + 1,
+            self.usk.keyer_index + 1,
+            VideoSource.INPUT_5
+        )
+        self.atem.setUSKParams(
+            self.usk.me_index + 1,
+            self.usk.keyer_index + 1,
+            preMultiplied=False,
+            gain=500,
+            clip=210,
+            invert=False
+        )

--- a/src/staldates/ui/widgets/OverlayControl.py
+++ b/src/staldates/ui/widgets/OverlayControl.py
@@ -76,6 +76,6 @@ class OverlayControl(QWidget):
 
     @with_atem
     def resetParams(self):
-            self.atem.setDSKFillSource(self.dsk.idx, VideoSource.INPUT_5)
-            self.atem.setDSKKeySource(self.dsk.idx, VideoSource.INPUT_5)
-            self.atem.setDSKParams(self.dsk.idx, preMultiplied=False, gain=500, clip=210)
+        self.atem.setDSKFillSource(self.dsk.idx, VideoSource.INPUT_5)
+        self.atem.setDSKKeySource(self.dsk.idx, VideoSource.INPUT_5)
+        self.atem.setDSKParams(self.dsk.idx, preMultiplied=False, gain=500, clip=210)

--- a/src/staldates/ui/widgets/OverlayControl.py
+++ b/src/staldates/ui/widgets/OverlayControl.py
@@ -93,6 +93,15 @@ class OverlayControl(QWidget):
             me=self.usk.me_index + 1
         )
         self.atem.performAutoTake(me=self.usk.me_index + 1)
+        self.atem.setNextTransition(
+            TransitionStyle.MIX,
+            bkgd=True,
+            key1=False,
+            key2=False,
+            key3=False,
+            key4=False,
+            me=self.usk.me_index + 1
+        )
 
     @with_atem
     def resetParams(self):

--- a/src/staldates/ui/widgets/OverlayControl.py
+++ b/src/staldates/ui/widgets/OverlayControl.py
@@ -64,7 +64,6 @@ class OverlayControl(QWidget):
         self.onAirButton.style().polish(self.onAirButton)
 
     def update_from_mix_transition(self):
-        print self.mixTransition
         self.rate.setValue(self.mixTransition.rate)
 
     @with_atem

--- a/src/staldates/ui/widgets/OverlayControl.py
+++ b/src/staldates/ui/widgets/OverlayControl.py
@@ -106,7 +106,7 @@ class OverlayControl(QWidget):
             self.usk.keyer_index + 1,
             VideoSource.INPUT_5
         )
-        self.atem.setUSKParams(
+        self.atem.setUSKLumaParams(
             self.usk.me_index + 1,
             self.usk.keyer_index + 1,
             preMultiplied=False,

--- a/src/staldates/ui/widgets/OverlayControl.py
+++ b/src/staldates/ui/widgets/OverlayControl.py
@@ -5,6 +5,8 @@ from staldates.ui.widgets.Buttons import ExpandingButton
 from staldates.VisualsSystem import with_atem
 from staldates.ui.widgets.TouchSpinner import FrameRateTouchSpinner
 
+from time import sleep
+
 
 class OverlayControl(QWidget):
 
@@ -93,6 +95,7 @@ class OverlayControl(QWidget):
             me=self.usk.me_index + 1
         )
         self.atem.performAutoTake(me=self.usk.me_index + 1)
+        sleep(0.1)
         self.atem.setNextTransition(
             TransitionStyle.MIX,
             bkgd=True,

--- a/src/staldates/ui/widgets/OverlayControl.py
+++ b/src/staldates/ui/widgets/OverlayControl.py
@@ -1,4 +1,4 @@
-from avx.devices.net.atem.constants import VideoSource
+from avx.devices.net.atem.constants import TransitionStyle, VideoSource
 from PySide.QtCore import Qt
 from PySide.QtGui import QWidget, QGridLayout, QLabel
 from staldates.ui.widgets.Buttons import ExpandingButton
@@ -90,9 +90,9 @@ class OverlayControl(QWidget):
             key2=self.usk.keyer_index == 1,
             key3=self.usk.keyer_index == 2,
             key4=self.usk.keyer_index == 3,
-            me=self.me
+            me=self.usk.me_index + 1
         )
-        self.atem.performAutoTake(me=self.me)
+        self.atem.performAutoTake(me=self.usk.me_index + 1)
 
     @with_atem
     def resetParams(self):

--- a/src/staldates/ui/widgets/Preferences.py
+++ b/src/staldates/ui/widgets/Preferences.py
@@ -97,10 +97,15 @@ class PreferencesWidget(QWidget):
         layout = QGridLayout()
 
         mixRate = FrameRateTouchSpinner()
-        mixRate.setValue(transition.rate)
         mixRate.setMaximum(250)
         mixRate.setMinimum(1)
         mixRate.valueChanged.connect(self.setMixRate)
+
+        def update_from_transition():
+            mixRate.setValue(transition.rate)
+
+        transition.changedProps.connect(update_from_transition)
+        update_from_transition()
 
         layout.addWidget(QLabel('Mix rate'), 0, 0)
         layout.addWidget(mixRate, 0, 1)

--- a/src/staldates/ui/widgets/TouchSpinner.py
+++ b/src/staldates/ui/widgets/TouchSpinner.py
@@ -23,6 +23,7 @@ class TouchSpinner(QWidget):
         self.lblValue = QLabel(self.formattedValue(self._value))
         self.lblValue.setAlignment(Qt.AlignHCenter | Qt.AlignVCenter)
         layout.addWidget(self.lblValue, 1)
+        layout.setAlignment(self.lblValue, Qt.AlignVCenter)
 
         self.btnPlus = ExpandingButton()
         self.btnPlus.setIcon(QIcon(":icons/list-add"))


### PR DESCRIPTION
This PR includes changes necessary to allow multiple instances of `av-control` to control different M/E buses on the video switcher.

Configuration is by the existing `~/.config/av-control/preferences.json` file; a key of `atem_me` with integer value (starting at `1` for M/E 1) will be used at startup to set the M/E used for video switching operations. There is intentionally no support for changing this value at runtime.

It's also necessary to switch from using a DSK to an USK for the "Visuals PC" key; DSKs can only appear on M/E 1 (since that is the most "downstream" of the M/E buses).

We make use of a new feature in `avx` to provide more detailed tally information than that provided by the ATEM, which only gives preview/program tally for M/E 1. Tally for the controlled M/E is shown with green/red borders as before; tally for other M/Es are shown by red or green dots on the input button. This should make it clear if an input is currently in use by the other bus.

Resolves #37.